### PR TITLE
Convert to envy

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,6 @@
 {deps, [
         {ibrowse, ".*", {git, "git://github.com/opscode/ibrowse",
-                            {tag, "v4.0.1.1"}}}
+                            {tag, "v4.0.1.1"}}},
+        {envy, ".*", {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}
         ]}.
 {erl_opts, [warnings_as_errors, debug_info]}.

--- a/src/mini_s3.erl
+++ b/src/mini_s3.erl
@@ -888,18 +888,14 @@ make_authorization(AccessKeyId, SecretKey, Method, ContentMD5, ContentType, Date
     {StringToSign, ["AWS ", AccessKeyId, $:, Signature]}.
 
 default_config() ->
-    case application:get_env(mini_s3, s3_defaults) of
-        undefined ->
-            throw({error, missing_s3_defaults});
-        {ok, Defaults} ->
-            case proplists:is_defined(key_id, Defaults) andalso
-                proplists:is_defined(secret_access_key, Defaults) of
-                true ->
-                    {key_id, Key} = proplists:lookup(key_id, Defaults),
-                    {secret_access_key, AccessKey} =
-                        proplists:lookup(secret_access_key, Defaults),
-                    #config{access_key_id=Key, secret_access_key=AccessKey};
-                false ->
-                    throw({error, missing_s3_defaults})
-            end
+    Defaults =  envy:get(mini_s3, s3_defaults, list),
+    case proplists:is_defined(key_id, Defaults) andalso
+        proplists:is_defined(secret_access_key, Defaults) of
+        true ->
+            {key_id, Key} = proplists:lookup(key_id, Defaults),
+            {secret_access_key, AccessKey} =
+                proplists:lookup(secret_access_key, Defaults),
+            #config{access_key_id=Key, secret_access_key=AccessKey};
+        false ->
+            throw({error, missing_s3_defaults})
     end.


### PR DESCRIPTION
Application:get_env requires validation of data types.  This logic has been 
duplicated several times.  This attempts to consolidate validation to a single
library, envy.
