### PR TITLE
Revert ibrowse dependency to its original repository

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,5 @@
 {deps, [
-        {ibrowse, ".*", {git, "git://github.com/opscode/ibrowse",
-                            {tag, "v4.0.1.1"}}},
+        {ibrowse, ".*", {git, "git://github.com/cmullaparthi/ibrowse", {tag, "v4.0.2"}}},
         {envy, ".*", {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}
         ]}.
 {erl_opts, [warnings_as_errors, debug_info]}.


### PR DESCRIPTION
This patch reverts the dependency on `ibrowse` to **v4.0.2** of its original repository. `ibrowse` has received a lot of fixes since it was forked by _Opscode_. The repository that `mini_s3` depends on has lagged behind and even contains an error in a format string in `ibrowse.erl`:

```
src/ibrowse.erl:627: Warning: wrong number of arguments in format call
```

The main issue with this is that the original repository is still using `ets` tables. It's not clear to me whether the move to use a `dict` in the _Opscode_ repository was really warranted or if it was just a precautionary measure.
