### PR TITLE
remove warnings_as_errors flag as it stops builds on R16B03

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,4 +3,4 @@
                             {tag, "v4.0.1.1"}}},
         {envy, ".*", {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}
         ]}.
-{erl_opts, [warnings_as_errors, debug_info]}.
+{erl_opts, [debug_info]}.


### PR DESCRIPTION
This makes mini_s3 compile on R16 and is the alternative fix suggested in #11 

cc @seth 
