### PR TITLE
Cachable S3 URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ ebin/*.beam
 ebin/*.app
 .eunit
 /.concrete/DEV_MODE
+.rebar

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 # This Makefile written by concrete
 #
-# {concrete_makefile_version, 1}
+# {concrete_makefile_version, 3}
 #
+# ANY CHANGES TO THIS FILE WILL BE OVERWRITTEN on `concrete update`
+# IF YOU WANT TO CHANGE ANY OF THESE LINES BELOW, COPY THEM INTO
+# custom.mk FIRST
+
 # Use this to override concrete's default dialyzer options of
 # -Wunderspecs
 # DIALYZER_OPTS = ...
@@ -17,6 +21,16 @@
 # If you want to add dependencies to the default "all" target provided
 # by concrete, add them here (along with make rules to build them if needed)
 # ALL_HOOK = ...
+
+## .DEFAULT_GOAL can be overridden in custom.mk if "all" is not the desired
+## default
+.DEFAULT_GOAL := all
+
+# custom.mk is totally optional
+custom_rules_file = $(wildcard custom.mk)
+ifeq ($(custom_rules_file),custom.mk)
+    include custom.mk
+endif
 
 concrete_rules_file = $(wildcard concrete.mk)
 ifeq ($(concrete_rules_file),concrete.mk)

--- a/concrete.mk
+++ b/concrete.mk
@@ -1,6 +1,60 @@
+# =============================================================================
+# Verify that the programs we need to run are installed on this system
+# =============================================================================
+ERL = $(shell which erl)
+
+ifeq ($(ERL),)
+$(error "Erlang not available on this system")
+endif
+
+# If building on travis, use the rebar in the current directory
+ifeq ($(TRAVIS),true)
+REBAR = $(CURDIR)/rebar
+endif
+
+# If there is a rebar in the current directory, use it
+ifeq ($(wildcard rebar),rebar)
+REBAR = $(CURDIR)/rebar
+endif
+
+# Fallback to rebar on PATH
+REBAR ?= $(shell which rebar)
+
+# And finally, prep to download rebar if all else fails
+ifeq ($(REBAR),)
+REBAR = $(CURDIR)/rebar
+endif
+
+# If we have a rebar.config.lock file, use it!
+ifeq ($(wildcard rebar.config.lock),rebar.config.lock)
+REBAR_CONFIG = rebar.config.lock
+else
+REBAR_CONFIG = rebar.config
+endif
+
+# This is the variable to use to respect the lock file
+REBARC = $(REBAR) -C $(REBAR_CONFIG)
+
+# For use on Travis CI, skip dialyzer for R14 and R15. Newer versions
+# have a faster dialyzer that is less likely to cause a build timeout.
+DIALYZER = dialyzer
+R14 = $(findstring R14,$(TRAVIS_OTP_RELEASE))
+R15 = $(findstring R15,$(TRAVIS_OTP_RELEASE))
+ifneq ($(R14),)
+DIALYZER = echo "SKIPPING dialyzer"
+endif
+ifneq ($(R15),)
+DIALYZER = echo "SKIPPING dialyzer"
+endif
+ifneq ($(SKIP_DIALYZER),)
+DIALYZER = echo "SKIPPING dialyzer"
+endif
+
+REBAR_URL=https://github.com/rebar/rebar/wiki/rebar
+
 DEPS ?= $(CURDIR)/deps
 
-DIALYZER_OPTS ?= -Wunderspecs
+DIALYZER_OPTS ?=
 
 # Find all the deps the project has by searching the deps dir
 ALL_DEPS = $(notdir $(wildcard deps/*))
@@ -14,28 +68,60 @@ DIALYZER_DEPS = $(foreach dep,$(DEPS_LIST),deps/$(dep)/ebin)
 
 DEPS_PLT = deps.plt
 
-ERLANG_DIALYZER_APPS = asn1 \
-                       compiler \
-                       crypto \
-                       edoc \
-                       erts \
-                       eunit \
-                       gs \
-                       hipe \
-                       inets \
-                       kernel \
-                       mnesia \
-                       observer \
-                       public_key \
-                       runtime_tools \
-                       ssl \
-                       stdlib \
-                       syntax_tools \
-                       tools \
-                       webtool \
-                       xmerl
+ERLANG_DIALYZER_APPS ?= asn1 \
+                        compiler \
+                        crypto \
+                        edoc \
+                        erts \
+                        inets \
+                        kernel \
+                        mnesia \
+                        public_key \
+                        ssl \
+                        stdlib \
+                        syntax_tools \
+                        tools \
+                        xmerl
 
-all: .concrete/DEV_MODE compile eunit dialyzer $(ALL_HOOK)
+PROJ = $(notdir $(CURDIR))
+
+# Let's compute $(BASE_PLT_ID) that identifies the base PLT to use for this project
+# and depends on your `$(ERLANG_DIALYZER_APPS)' list and your erlang version
+ERLANG_VERSION := $(shell ERL_FLAGS="" $(ERL) -eval 'io:format("~s~n", [erlang:system_info(otp_release)]), halt().' -noshell)
+MD5_BIN := $(shell which md5 || which md5sum)
+ifeq ($(MD5_BIN),)
+# neither md5 nor md5sum, we just take the project name
+BASE_PLT_ID := $(PROJ)
+else
+BASE_PLT_ID := $(word 1, $(shell echo $(ERLANG_DIALYZER_APPS) | $(MD5_BIN)))
+endif
+
+ifeq ($(TRAVIS),true)
+## If we're running on travis, pull the plt from S3
+## We got them from https://github.com/esl/erlang-plts
+## To add to the collection make sure they're public and match the erlang version
+## reported by erlang:system_info(otp_release)
+## s3cmd put --acl-public --guess-mime-type <FILENAME> s3://concrete-plts
+
+BASE_PLT := travis-erlang-$(ERLANG_VERSION).plt
+BASE_PLT_URL := http://s3.amazonaws.com/concrete-plts/$(BASE_PLT)
+else
+BASE_PLT := ~/.concrete_dialyzer_plt_$(BASE_PLT_ID)_$(ERLANG_VERSION).plt
+endif
+
+## The recursive call to $(MAKE) is here to make sure that we use a verion of
+## DIALYZER_DEPS that's built after $(DEPS) is made. If we didn't do this,
+## dialyzer wouldn't be able to figure out that it needs to build deps.plt
+all: .concrete/DEV_MODE $(DEPS)
+	@$(MAKE) all_but_dialyzer dialyzer
+
+all_but_dialyzer: .concrete/DEV_MODE compile eunit $(ALL_HOOK)
+
+$(REBAR):
+	curl -Lo rebar $(REBAR_URL) || wget $(REBAR_URL)
+	chmod a+x rebar
+
+get-rebar: $(REBAR)
 
 .concrete/DEV_MODE:
 	@mkdir -p .concrete
@@ -43,50 +129,132 @@ all: .concrete/DEV_MODE compile eunit dialyzer $(ALL_HOOK)
 
 # Clean ebin and .eunit of this project
 clean:
-	@rebar clean skip_deps=true
+	@$(REBARC) clean skip_deps=true
 
 # Clean this project and all deps
+# Newer rebar requires -r to recursively clean
 allclean:
-	@rebar clean
+	@($(REBARC) --help 2>&1|grep -q recursive && $(REBARC) -r clean) || $(REBARC) clean
 
 compile: $(DEPS)
-	@rebar compile
+	@$(REBARC) compile
 
 $(DEPS):
-	@rebar get-deps
+	@$(REBARC) get-deps
 
 # Full clean and removal of all deps. Remove deps first to avoid
 # wasted effort of cleaning deps before nuking them.
 distclean:
 	@rm -rf deps $(DEPS_PLT)
-	@rebar clean
+	@$(REBARC) clean
 
 eunit:
-	@rebar skip_deps=true eunit
+	@$(REBARC) skip_deps=true eunit
 
 test: eunit
 
 # Only include local PLT if we have deps that we are going to analyze
 ifeq ($(strip $(DIALYZER_DEPS)),)
-dialyzer: ~/.dialyzer_plt
-	@dialyzer $(DIALYZER_OPTS) -r ebin
+dialyzer: $(BASE_PLT)
+	@$(DIALYZER) $(DIALYZER_OPTS) --plts $(BASE_PLT) -r ebin
 else
-dialyzer: ~/.dialyzer_plt $(DEPS_PLT)
-	@dialyzer $(DIALYZER_OPTS) --plts ~/.dialyzer_plt $(DEPS_PLT) -r ebin
+dialyzer: $(BASE_PLT) $(DEPS_PLT)
+	@$(DIALYZER) $(DIALYZER_OPTS) --plts $(BASE_PLT) $(DEPS_PLT) -r ebin
 
 $(DEPS_PLT):
-	@dialyzer --build_plt $(DIALYZER_DEPS) --output_plt $(DEPS_PLT)
+	@$(DIALYZER) --build_plt $(DIALYZER_DEPS) --output_plt $(DEPS_PLT)
 endif
 
-~/.dialyzer_plt:
-	@echo "ERROR: Missing ~/.dialyzer_plt. Please wait while a new PLT is compiled."
-	dialyzer --build_plt --apps $(ERLANG_DIALYZER_APPS)
-	@echo "now try your build again"
+$(BASE_PLT):
+ifeq ($(TRAVIS),true)
+		@echo "Attempting to download PLT: $(BASE_PLT_URL)."
+		-wget $(BASE_PLT_URL)
+
+		@if [ -f $(BASE_PLT) ] ; then \
+			echo "Downloaded PLT successfully to $(BASE_PLT)" ; \
+		else \
+			echo "Download failed. Please wait while a new PLT is compiled." ; \
+			$(DIALYZER) --build_plt --apps $(ERLANG_DIALYZER_APPS) --output_plt $(BASE_PLT) ; \
+			echo "now try your build again" ; \
+		fi;
+
+else
+		@echo "Missing $(BASE_PLT). Please wait while a new PLT is compiled."
+		$(DIALYZER) --build_plt --apps $(ERLANG_DIALYZER_APPS) --output_plt $(BASE_PLT)
+		@echo "now try your build again"
+endif
 
 doc:
-	@rebar doc skip_deps=true
+	@$(REBARC) doc skip_deps=true
+
+shell:
+	@$(ERL) -pa deps/*/ebin ebin .eunit
 
 tags:
 	find src deps -name "*.[he]rl" -print | etags -
 
-.PHONY: all compile eunit test dialyzer clean allclean distclean doc tags
+# Releases via relx. we will install a local relx, as we do for rebar,
+# if we don't find one on PATH.
+RELX_CONFIG ?= $(CURDIR)/relx.config
+RELX = $(shell which relx)
+RELX_OPTS ?=
+RELX_OUTPUT_DIR ?= _rel
+ifeq ($(RELX),)
+RELX = $(CURDIR)/relx
+RELX_VERSION = 1.0.4
+else
+RELX_VERSION = $(shell relx --version)
+endif
+RELX_URL = https://github.com/erlware/relx/releases/download/v$(RELX_VERSION)/relx
+
+# relx introduced a breaking change in v1: the output doesn't have the same structure
+# see https://github.com/erlware/relx/releases/tag/v1.0.0
+ifeq ($(shell echo $(RELX_VERSION) | head -c 1), 0)
+RELX_RELEASE_DIR = $(RELX_OUTPUT_DIR)
+else
+RELX_RELEASE_DIR = $(RELX_OUTPUT_DIR)/$(PROJ)
+endif
+
+$(RELX):
+	curl -Lo relx $(RELX_URL) || wget $(RELX_URL)
+	chmod a+x relx
+
+rel: relclean all_but_dialyzer $(RELX)
+	@$(RELX) -c $(RELX_CONFIG) -o $(RELX_OUTPUT_DIR) $(RELX_OPTS)
+
+devrel: rel
+devrel: lib_dir=$(wildcard $(RELX_RELEASE_DIR)/lib/$(PROJ)-* )
+devrel:
+	@/bin/echo Symlinking deps and apps into release
+	@rm -rf $(lib_dir); mkdir -p $(lib_dir)
+	@ln -sf `pwd`/ebin $(lib_dir)
+	@ln -sf `pwd`/priv $(lib_dir)
+	@ln -sf `pwd`/src $(lib_dir)
+
+relclean:
+	rm -rf $(RELX_OUTPUT_DIR)
+
+## Release prep and dep locking. These recipes use $(REBAR), not
+## $(REBARC) in order to NOT use the lock file since they are
+## concerned with the task of updating the lock file.
+BUMP ?= patch
+prepare_release: distclean unlocked_deps unlocked_compile update_locked_config rel
+	@echo 'release prepared, bumping version'
+	@$(REBAR) bump-rel-version version=$(BUMP)
+
+unlocked_deps:
+	@echo 'Fetching deps as: rebar -C rebar.config'
+	@$(REBAR) -C rebar.config get-deps
+
+# When running the prepare_release target, we have to ensure that a
+# compile occurs using the unlocked rebar.config. If a dependency has
+# been removed, then using the locked version that contains the stale
+# dep will cause a compile error.
+unlocked_compile:
+	@$(REBAR) -C rebar.config compile
+
+update_locked_config:
+	@$(REBAR) lock-deps skip_deps=true
+
+
+.PHONY: all all_but_dialyzer compile eunit test dialyzer clean allclean relclean distclean doc tags get-rebar rel devrel

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,18 @@
+%% -*- mode: erlang -*-
+%% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 ft=erlang et
 {deps, [
-        {ibrowse, ".*", {git, "git://github.com/opscode/ibrowse",
-                            {tag, "v4.0.1.1"}}},
-        {envy, ".*", {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}
-        ]}.
+    {ibrowse, ".*", {git, "git://github.com/opscode/ibrowse",
+                        {tag, "v4.0.1.1"}}},
+    {envy, ".*", {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}
+  ]}.
+
+%% Add dependencies that are only needed for development here. These
+%% dependencies will be hidden from upstream projects using this code
+%% as a dependency.
+{dev_only_deps,
+  [
+    {meck, "0.8.2", {git, "git://github.com/eproxus/meck.git", {tag, "0.8.2"}}}
+  ]}.
+
 {erl_opts, [debug_info]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -6,7 +6,7 @@
 %%
 %% YOU SHOULDN'T NEED TO EDIT THIS FILE
 %%
-{concrete_rebar_script_version, 1}.
+{concrete_rebar_script_version, 3}.
 
 %% We need the following helper function to merge dev only options
 %% into the values provided by rebar.config.
@@ -15,16 +15,18 @@
 %% in proplist `C'. Don't duplicate items. New Items are added to the
 %% front of existing items. It is an error if the value at `Key' is
 %% not a list in `C'.
-MergeConfig = fun({Key, ToAdd}, C) ->
+MergeConfig = fun(skip, C) ->
+                      C;
+                 ({Key, ToAdd}, C) ->
                       case lists:keyfind(Key, 1, C) of
                           false ->
                               lists:keystore(Key, 1, C, {Key, ToAdd});
                           {Key, List} when is_list(List) ->
                               %% remove items in ToAdd already in List
                               ToAdd1 = [ I || I <- ToAdd, not lists:member(I, List) ],
-                              lists:keystore(Key, 1, C, {Key, ToAdd1 ++ List })
+                              lists:keystore(Key, 1, C, {Key, List ++ ToAdd1 })
                       end
-              end.
+              end,
 
 %% -- Add development only options if we are a top-level build  --
 %%
@@ -35,52 +37,57 @@ MergeConfig = fun({Key, ToAdd}, C) ->
 
 %% This macro can be used to conditionally enable code (e.g. tests)
 %% that depend on development only dependencies.
-ErlOpts = {erl_opts, [
-    {d, 'DEV_ONLY'}
-]},
+ErlOpts = {erl_opts, [{d, 'DEV_ONLY'}]},
 
 %% Development only dependencies can be specified in the main
 %% rebar.config. This file should not need to be edited directly.
 DevOnlyDeps = case lists:keyfind(dev_only_deps, 1, CONFIG) of
                   false ->
-                      [];
+                      skip;
                   {dev_only_deps, DOD} ->
-                      DOD
+                      {deps, DOD}
               end,
 
-EdownMe =
-fun(C) ->
-        %% Unless rebar.config contains `{use_edown, false}', we'll
-        %% wire it up. However, we'll only add the required edoc_opts
-        %% if none have been provided.
-        case proplists:get_value(use_edown, C) of
-            false ->
-                C;
-            _ ->
-                %% only add edoc_opts if none are present
-                C1 = case lists:keymember(edoc_opts, 1, C) of
-                         true ->
-                             C;
-                         false ->
-                             MergeConfig({edoc_opts, [{doclet, edown_doclet}]}, C)
-                     end,
-                MergeConfig({deps,
-                             [{edown, ".*",
-                               {git, "git://github.com/seth/edown.git",
-                                {branch, "master"}}}]},
-                            C1)
-        end
-end,
+EDown = case proplists:get_value(use_edown, CONFIG) of
+               false ->
+                   skip;
+               _ ->
+                DocOpts = case lists:keymember(edoc_opts, 1, CONFIG) of
+                              true ->
+                                  skip;
+                              false ->
+                                  {edoc_opts, [{doclet, edown_doclet}]}
+                          end,
+                [DocOpts,
+                 {deps,
+                  [{edown, ".*",
+                    {git, "git://github.com/seth/edown.git",
+                     {branch, "master"}}}]}]
+           end,
 
-Deps = {deps, DevOnlyDeps},
+LockDeps = case proplists:get_value(use_lock_deps, CONFIG) of
+               false ->
+                   skip;
+               V ->
+                   Tag = case V of
+                             {_, _} = T -> T;
+                             _ -> {branch, "master"}
+                         end,
+                   [{deps,
+                     [{rebar_lock_deps_plugin, ".*",
+                       {git, "git://github.com/seth/rebar_lock_deps_plugin.git",
+                        Tag}}]},
+                    {plugins, [rebar_lock_deps_plugin]}]
+           end,
 
 ConfigPath = filename:dirname(SCRIPT),
 DevMarker = filename:join([ConfigPath, ".concrete/DEV_MODE"]),
 
 case filelib:is_file(DevMarker) of
     true ->
+        ToMerge = lists:flatten([DevOnlyDeps, LockDeps, EDown, ErlOpts]),
         lists:foldl(fun(I, C) -> MergeConfig(I, C) end,
-                    EdownMe(CONFIG), [Deps, ErlOpts]);
+                    CONFIG, ToMerge);
     false ->
         %% If the .concrete/ marker is not present, this script simply
         %% returns the config specified in rebar.config. This will be

--- a/src/mini_s3.erl
+++ b/src/mini_s3.erl
@@ -65,11 +65,11 @@
 
 -ifdef(TEST).
 -compile([export_all]).
+-include_lib("eunit/include/eunit.hrl").
 -endif.
 
 -include("internal.hrl").
 -include_lib("xmerl/include/xmerl.hrl").
--include_lib("eunit/include/eunit.hrl").
 
 -export_type([config/0,
               bucket_attribute_name/0,


### PR DESCRIPTION
### Never tell me the odds!

Every time we create a signed S3 URL, it expires in X minutes. Since the expiration time is included in the URL's query string, as seconds since the epoch (1/1/70)

The existing logic to compute the expiry time

```erlang
expiration_time(TimeToLive) ->
    Epoch = calendar:datetime_to_gregorian_seconds({{1970, 1, 1}, {0, 0, 0}}),
    Now = calendar:datetime_to_gregorian_seconds(erlang:universaltime()),
    (Now - Epoch) + TimeToLive.
```

So, you can't cache these. You just can't. Unless it was requested in the same second because of the call to `erlang:universaltime()`. So what to do?

Well, what if we set an interval size. In the following example, I'll use 15 minute intervals, and a TimeToLive of 1 hour.

We divide the day into intervals, so every URL generated in that interval is the same.


```
 +--A--a--aaa---+---------B----+--C---ccccc---+-----Dddd----d+
1:00           1:15           1:30           1:45           2:00
```

Look at the URL `A` genrated at 1:03, until 1:15 they'll all be set to expire at 2:15. These are the lowec case `a` URLs, which just means they're the same, but they're not "new".

Once it's 1:15, we're in a new inteval, but we don't try getting a URL until 1:25. We set that one to expire at 2:30 (1hr + the remaining time in the interval). 

Nobody asks for a URL until after 1:30, so the URL `B` is only used once and is never asked for again. Oh well. We played the odds and lost this time. It's not the end of the world.

At 1:33, the URL `C` is generated and this interval gets used alot, so it's good that we have this feature.

You get the idea. Over the course of the day we will only ever generate 96 unique expiration times, as opposed to a new expiration time for every URL requested.

Now, 15m may not be the optimal window size. If we went with 60m then we'd only generate 24 unique URLs per day. That's why we've made it configurable.

Take the existing API for generating a URL:

```erlang
-spec s3_url(atom(), string(), string(), integer(),
             proplists:proplist(), config()) -> binary().
s3_url(Method, BucketName, Key, Lifetime, RawHeaders, Config)
```

`Lifetime` is an `integer()`. The number of second that this thing should expire in. This would have been `3600`, the number of seconds in an hour. If you still do it this way, it will work just as it did before.

We've added a tuple `{Lifetime, IntervalSize}` version of the argument. 

```erlang
-spec s3_url(atom(), string(), string(), integer() | {integer(), integer()},
             proplists:proplist(), config()) -> binary().
s3_url(Method, BucketName, Key, Lifetime, RawHeaders, Config)
```

In the above example with a 15m interval, we'd have passed in `{3600, 900}` which would essentially make the lifetime = 3600 + (some number between 0 and 900).