### PR TITLE
Expose ssl_opts for ibrowse via new/5

### DIFF
--- a/src/internal.hrl
+++ b/src/internal.hrl
@@ -22,4 +22,5 @@
           s3_url="http://s3.amazonaws.com"::string(),
           access_key_id::string(),
           secret_access_key::string(),
-          bucket_access_type=virtual_hosted::mini_s3:bucket_access_type() }).
+          bucket_access_type=virtual_hosted::mini_s3:bucket_access_type(),
+          ssl_options=[]::proplists:proplist()}).

--- a/src/mini_s3.erl
+++ b/src/mini_s3.erl
@@ -24,6 +24,7 @@
 -export([new/2,
          new/3,
          new/4,
+         new/5,
          create_bucket/3,
          create_bucket/4,
          delete_bucket/1,
@@ -137,6 +138,15 @@ new(AccessKeyID, SecretAccessKey, Host, BucketAccessType) ->
      secret_access_key=SecretAccessKey,
      s3_url=Host,
      bucket_access_type=BucketAccessType}.
+
+-spec new(string(), string(), string(), bucket_access_type(), proplists:proplist()) -> config().
+new(AccessKeyID, SecretAccessKey, Host, BucketAccessType, SslOpts) ->
+    #config{
+     access_key_id=AccessKeyID,
+     secret_access_key=SecretAccessKey,
+     s3_url=Host,
+     bucket_access_type=BucketAccessType,
+     ssl_options=SslOpts}.
 
 
 
@@ -826,7 +836,8 @@ s3_xml_request(Config, Method, Host, Path, Subresource, Params, POSTData, Header
     end.
 
 s3_request(Config = #config{access_key_id=AccessKey,
-                            secret_access_key=SecretKey},
+                            secret_access_key=SecretKey,
+                            ssl_options=SslOpts},
            Method, Host, Path, Subresource, Params, POSTData, Headers) ->
     {ContentMD5, ContentType, Body} =
         case POSTData of
@@ -873,20 +884,22 @@ s3_request(Config = #config{access_key_id=AccessKey,
                                     Subresource =:= "" -> [$?, ms3_http:make_query_string(Params)];
                                     true -> [$&, ms3_http:make_query_string(Params)]
                                 end]),
+    IbrowseOpts = [ {ssl_options, SslOpts} ],
     Response = case Method of
                    get ->
-                       ibrowse:send_req(RequestURI, RequestHeaders1, Method);
+                       ibrowse:send_req(RequestURI, RequestHeaders1, Method, [], IbrowseOpts);
                    delete ->
-                       ibrowse:send_req(RequestURI, RequestHeaders1, Method);
+                       ibrowse:send_req(RequestURI, RequestHeaders1, Method, [], IbrowseOpts);
                    head ->
                        %% ibrowse is unable to handle HEAD request responses that are sent
                        %% with chunked transfer-encoding (why servers do this is not
                        %% clear). While we await a fix in ibrowse, forcing the HEAD request
                        %% to use HTTP 1.0 works around the problem.
+                       IbrowseOpts1 = [{http_vsn, {1, 0}} | IbrowseOpts],
                        ibrowse:send_req(RequestURI, RequestHeaders1, Method, [],
-                                        [{http_vsn, {1, 0}}]);
+                                        IbrowseOpts1);
                    _ ->
-                       ibrowse:send_req(RequestURI, RequestHeaders1, Method, Body)
+                       ibrowse:send_req(RequestURI, RequestHeaders1, Method, Body, IbrowseOpts)
                end,
     case Response of
         {ok, Status, ResponseHeaders0, ResponseBody} ->


### PR DESCRIPTION
This is intended to enable using mTLS for bookshelf in downstream
oc_erchef

Signed-off-by: Daniel DeLeo <dan@chef.io>