### PR TITLE
Use the mainline ibrowse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: erlang
+otp_release:
+  - 18.3
+  - 19.3
+
+  
+install: true
+script: rebar3 eunit
+
+branches:
+  only:
+    - master
+
+
+

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,9 @@
 %% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang et
 {deps, [
-        {ibrowse, {git, "https://github.com/chef/ibrowse", {tag, "v4.0.1.1"}}},
+        {ibrowse, ".*",
+         %% Pin here, becase 555f707 (pr #155) introduces an ipv6 bug we've not fixed
+         {git, "https://github.com/cmullaparthi/ibrowse.git", {ref, "c97136cfb61fcc6f39d4e7da47372a64f7fca04e"}}},
         {envy, {git, "https://github.com/markan/envy.git", {branch, "master"}}}
        ]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -3,6 +3,6 @@
        {ref,"0148fb4b7ed0e188511578e98b42d6e7dde0ebd1"}},
   0},
  {<<"ibrowse">>,
-  {git,"https://github.com/chef/ibrowse",
-       {ref,"8f3f6a3a30730b193cc340a8885a960586dc98de"}},
+  {git,"git://github.com/cmullaparthi/ibrowse.git",
+       {ref,"c97136cfb61fcc6f39d4e7da47372a64f7fca04e"}},
   0}].


### PR DESCRIPTION
We've been using a very old fork of ibrowse; the mainline (cmullaparthi/ibrowse)
appears to have nearly all the things we forked it for in the first place.

Unfortunately a recent commit 555f707 (pr #155) breaks things where an
ipv6 address is reported from DNS but isn't routable. So we are
pinning to a slightly older version. This is a short term fix to get
things running while a better solution is found.

Signed-off-by: Mark Anderson <mark@chef.io>

Use locked version of ibrowse