### PR TITLE
Update erlang versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,13 @@
 language: erlang
 otp_release:
-  - 18.3
+  - 21.0
+  - 20.3
   - 19.3
+  - 18.3
 
-  
 install: true
 script: rebar3 eunit
 
 branches:
   only:
     - master
-
-
-

--- a/rebar.config
+++ b/rebar.config
@@ -8,8 +8,10 @@
         {envy, {git, "https://github.com/markan/envy.git", {branch, "master"}}}
        ]}.
 
-{profiles, [{
-              test, [{deps, [meck]}]
+{profiles, [{ test, [
+                     {deps, [meck]},
+                     {erl_opts, [nowarn_export_all]}
+                    ]
             }]}.
 
 {erl_opts, [debug_info, warnings_as_errors]}.


### PR DESCRIPTION
Bump erlang versions in travis.yml  and silence warnings in tests.
This should be rebased and merged after #26 (or just combined with it)