### PR TITLE
User erlang:md5 instead of crypto md5 for FIPS compatibility.

### DIFF
--- a/src/mini_s3.erl
+++ b/src/mini_s3.erl
@@ -842,7 +842,7 @@ s3_request(Config = #config{access_key_id=AccessKey,
     {ContentMD5, ContentType, Body} =
         case POSTData of
             {PD, CT} ->
-                {base64:encode(crypto:hash(md5,PD)), CT, PD};
+                {base64:encode(erlang:md5(PD)), CT, PD};
             PD ->
                 %% On a put/post even with an empty body we need to
                 %% default to some content-type


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

## Description
This will let us use crypto from erlang 20 instead of the patch that we currently use.

The call to md5 is used in the signing of the header of the request being made.
https://github.com/chef/mini_s3/blob/praj/FIPS/src/mini_s3.erl#L863-L873

## Related Issue
https://github.com/chef/chef-server/issues/1877

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
