### PR TITLE
Vhost

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,10 +2,8 @@
 %% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang et
 {deps, [
-        {ibrowse, ".*",
-         %% Pin here, becase 555f707 (pr #155) introduces an ipv6 bug we've not fixed
-         {git, "https://github.com/cmullaparthi/ibrowse.git", {ref, "c97136cfb61fcc6f39d4e7da47372a64f7fca04e"}}},
-        {envy, {git, "https://github.com/markan/envy.git", {branch, "master"}}}
+        {envy,    ".*", {git, "https://github.com/markan/envy.git",          {branch, "master"}}},
+        {erlcloud,".*", {git, "https://github.com/chef/erlcloud.git",        {branch, "lbaker/presigned-headers"}}}
        ]}.
 
 {profiles, [{ test, [

--- a/src/internal.hrl
+++ b/src/internal.hrl
@@ -22,5 +22,5 @@
           s3_url="http://s3.amazonaws.com"::string(),
           access_key_id::string(),
           secret_access_key::string(),
-          bucket_access_type=virtual_hosted::mini_s3:bucket_access_type(),
+          bucket_access_type=vhost::mini_s3:bucket_access_type(),
           ssl_options=[]::proplists:proplist()}).

--- a/src/mini_s3.app.src
+++ b/src/mini_s3.app.src
@@ -18,19 +18,18 @@
 %% under the License.
 %%
 
-
 {application, mini_s3,
  [{description, "A Robust Amazon S3 client for Erlang"},
   {vsn, "0.0.1"},
   {registered, []},
-  {applications, [stdlib,
+  {applications, [erlcloud,
+                  stdlib,
                   kernel,
                   sasl,
                   public_key,
                   crypto,
                   ssl,
-                  xmerl,
-                  ibrowse]},
+                  xmerl]},
   {modules, []},
   {env, []}
  ]

--- a/src/mini_s3.erl
+++ b/src/mini_s3.erl
@@ -194,7 +194,7 @@ new(AccessKeyID, SecretAccessKey, Url) ->
     %%  https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/
     %%  https://github.com/chef/chef-server/issues/2088
     %%  https://github.com/chef/chef-server/issues/1911
-    (erlcloud_s3:new(AccessKeyID, SecretAccessKey, Host2++Path1, Port))#aws_config{s3_scheme=Scheme, s3_bucket_after_host=true, s3_bucket_access_method=path}.
+    (erlcloud_s3:new(AccessKeyID, SecretAccessKey, Host2++Path1, Port))#aws_config{s3_scheme=Scheme, s3_bucket_after_host=false, s3_bucket_access_method=vhost}.
 
 % old mini_s3:
 %   -spec new(string(), string(), string(), bucket_access_type()) -> aws_config().

--- a/src/mini_s3.erl
+++ b/src/mini_s3.erl
@@ -21,91 +21,101 @@
 
 -module(mini_s3).
 
--export([new/2,
-         new/3,
-         new/4,
-         new/5,
-         create_bucket/3,
-         create_bucket/4,
-         delete_bucket/1,
-         delete_bucket/2,
-         get_bucket_attribute/2,
-         get_bucket_attribute/3,
-         list_buckets/0,
-         list_buckets/1,
-         set_bucket_attribute/3,
-         set_bucket_attribute/4,
-         list_objects/2,
-         list_objects/3,
-         list_object_versions/2,
-         list_object_versions/3,
+-export([
          copy_object/5,
          copy_object/6,
+         create_bucket/3,
+         create_bucket/4,
+         delete_bucket/2,
          delete_object/2,
          delete_object/3,
          delete_object_version/3,
          delete_object_version/4,
-         get_object/3,
+         get_bucket_attribute/2,
+         get_bucket_attribute/3,
          get_object/4,
          get_object_acl/2,
          get_object_acl/3,
          get_object_acl/4,
          get_object_torrent/2,
          get_object_torrent/3,
-         get_object_metadata/3,
          get_object_metadata/4,
-         s3_url/6,
-         put_object/5,
+         list_buckets/1,
+         list_objects/2,
+         list_objects/3,
+         list_object_versions/2,
+         list_object_versions/3,
+         new/3,
+         new/4,
+         new/5,
          put_object/6,
+         s3_url/6,
+         s3_url/7,
+         set_bucket_attribute/3,
+         set_bucket_attribute/4,
          set_object_acl/3,
-         set_object_acl/4]).
+         set_object_acl/4
+]).
 
--export([manual_start/0,
-         make_authorization/10,
-         make_signed_url_authorization/5,
-         universaltime/0]).
+-export([make_authorization/10,
+         manual_start/0,
+         make_expire_win/2,
+         universaltime/0
+]).
+
+-include_lib("xmerl/include/xmerl.hrl").
+-include_lib("erlcloud/include/erlcloud_aws.hrl").
 
 -ifdef(TEST).
--compile([export_all]).
--include_lib("eunit/include/eunit.hrl").
+-compile([export_all, nowarn_export_all]).
 -endif.
 
--include("internal.hrl").
--include_lib("xmerl/include/xmerl.hrl").
+-export([expiration_time/1]).
 
--export_type([config/0,
-              bucket_attribute_name/0,
-              bucket_acl/0,
-              location_constraint/0]).
+-type s3_bucket_attribute_name() :: acl
+                                  | location
+                                  | logging
+                                  | request_payment
+                                  | versioning
+                                  | notification.
 
--opaque config() :: #config{}.
+-type s3_bucket_acl() :: private
+                       | public_read
+                       | public_read_write
+                       | authenticated_read
+                       | bucket_owner_read
+                       | bucket_owner_full_control.
 
--type bucket_access_type() :: virtual_domain | path.
+-type s3_location_constraint() :: none
+                                | us_west_1
+                                | eu
+                                | 'us-east-1'
+                                | 'us-east-2'
+                                | 'us-west-1'
+                                | 'us-west-2'
+                                | 'ca-central-1'
+                                | 'eu-west-1'
+                                | 'eu-west-2'
+                                | 'eu-west-3'
+                                | 'eu-north-1'
+                                | 'eu-central-1'
+                                | 'ap-south-1'
+                                | 'ap-southeast-1'
+                                | 'ap-southeast-2'
+                                | 'ap-northeast-1'
+                                | 'ap-northeast-2'
+                                | 'ap-northeast-3'
+                                | 'ap-east-1'
+                                | 'me-south-1'
+                                | 'sa-east-1'.
 
--type bucket_attribute_name() :: acl
-                               | location
-                               | logging
-                               | request_payment
-                               | versioning.
+-export_type([aws_config/0,
+              s3_bucket_attribute_name/0,
+              s3_bucket_acl/0,
+              s3_location_constraint/0]).
 
--type settable_bucket_attribute_name() :: acl
-                                        | logging
-                                        | request_payment
-                                        | versioning.
+-type bucket_access_type() :: vhost | path.
 
--type bucket_acl() :: private
-                    | public_read
-                    | public_read_write
-                    | authenticated_read
-                    | bucket_owner_read
-                    | bucket_owner_full_control.
-
--type location_constraint() :: none
-                             | us_west_1
-                             | eu.
-
-
-%%
 %% This is a helper function that exists to make development just a
 %% wee bit easier
 -spec manual_start() -> ok.
@@ -115,299 +125,229 @@ manual_start() ->
     application:start(ssl),
     application:start(inets).
 
--spec new(string(), string()) -> config().
+-spec discern_ipv(string()) -> pos_integer().
+discern_ipv(Url) ->
+    case lists:member($[, Url) andalso lists:member($], Url) of
+        true  -> 6;
+        false -> 4
+    end.
 
-new(AccessKeyID, SecretAccessKey) ->
-    #config{
-     access_key_id=AccessKeyID,
-     secret_access_key=SecretAccessKey}.
+-spec new(string() | binary(), string() | binary(), string()) -> aws_config().
+new(AccessKeyID, SecretAccessKey, Url) ->
+    Ipv     = discern_ipv(Url),
 
--spec new(string(), string(), string()) -> config().
+    Parse   =
+        case Url of
+            % uri_string:parse fails in certain cases of missing scheme. detect and fix.
+            [$h, $t, $t, $p,     $:, $/, $/ | _] -> uri_string:parse(                 Url );
+            [$h, $t, $t, $p, $s, $:, $/, $/ | _] -> uri_string:parse(                 Url );
+            _                                    -> uri_string:parse(["no-scheme://", Url])
+        end,
 
-new(AccessKeyID, SecretAccessKey, Host) ->
-    #config{
-     access_key_id=AccessKeyID,
-     secret_access_key=SecretAccessKey,
-     s3_url=Host}.
+    Path0   = maps:get(path  , Parse           ),
+    Host0   = maps:get(host  , Parse, undefined),
+    Scheme0 = maps:get(scheme, Parse, undefined),
+    Port0   = maps:get(port  , Parse, undefined),
 
--spec new(string(), string(), string(), bucket_access_type()) -> config().
+    % detect and repair any erroneous parse.
+    % uri_string:parse parses URLs shaped as "host" or "host:port" incorrectly, e.g.:
+    %
+    %   % should be #{host => "host"}
+    %   > uri_string:parse("host").
+    %   #{path => "host"}
+    %
+    %   % should be #{host => "host", port => 80}
+    %   > uri_string:parse("host:80").
+    %   #{path => "80",scheme => "host"}
+    {Scheme1, Host1, Path1, Port1} =
+        case {Scheme0, Host0, Path0, Port0} of
+            {undefined, undefined, _, undefined} when Path0 /= undefined
+                                                 -> {undefined, Path0,   "",    undefined             };
+            {_,         undefined, _, undefined} -> {undefined, Scheme0, "",    list_to_integer(Path0)};
+             _                                   -> {Scheme0,   Host0,   Path0, Port0                 }
+        end,
 
+    Host2   = case Ipv of 4 -> Host1; _ -> "[" ++ Host1 ++ "]" end,
+
+    {Scheme, Port} =
+        case {Scheme1, Port1} of
+            {undefined,   undefined} -> {"https://",   443};
+            {undefined,          80} -> {"http://",     80};
+            {undefined,           _} -> {"https://", Port1};
+            {"http",      undefined} -> {"http://",     80};
+            {"http",              _} -> {"http://",  Port1};
+            {"https",     undefined} -> {"https://",   443};
+            {"https",             _} -> {"https://", Port1};
+            {"no-scheme", undefined} -> {"https://",   443};
+            {"no-scheme",        80} -> {"http://",     80};
+            {"no-scheme",         _} -> {"https://", Port1};
+            _                        -> {Scheme1,    Port1}
+        end,
+
+    %% bookshelf wants bucketname after host e.g. https://api.chef-server.dev:443/bookshelf.
+    %% s3 wants bucketname before host (actually, it takes it either way) e.g. https://bookshelf.api.chef-server.dev:443.
+    %%
+    %% UPDATE
+    %% amazon: "Buckets created after September 30, 2020, will support only virtual hosted-style requests.
+    %% Path-style requests will continue to be supported for buckets created on or before this date."
+    %% for further discussion, see:
+    %%  https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/
+    %%  https://github.com/chef/chef-server/issues/2088
+    %%  https://github.com/chef/chef-server/issues/1911
+    (erlcloud_s3:new(AccessKeyID, SecretAccessKey, Host2++Path1, Port))#aws_config{s3_scheme=Scheme, s3_bucket_after_host=true, s3_bucket_access_method=path}.
+
+% old mini_s3:
+%   -spec new(string(), string(), string(), bucket_access_type()) -> aws_config().
+%   mini_s3:new(accesskey, secretaccesskey, host, bucketaccesstype)
+-spec new(string() | binary(), string() | binary(), string(), bucket_access_type()) -> aws_config().
 new(AccessKeyID, SecretAccessKey, Host, BucketAccessType) ->
-    #config{
-     access_key_id=AccessKeyID,
-     secret_access_key=SecretAccessKey,
-     s3_url=Host,
-     bucket_access_type=BucketAccessType}.
+    {BucketAccessMethod, BucketAfterHost} = case BucketAccessType of path -> {path, true}; _ -> {vhost, false} end,
+    Config = new(AccessKeyID, SecretAccessKey, Host),
+    Config#aws_config{
+        s3_bucket_access_method=BucketAccessMethod,
+        s3_bucket_after_host=BucketAfterHost
+    }.
 
--spec new(string(), string(), string(), bucket_access_type(), proplists:proplist()) -> config().
-new(AccessKeyID, SecretAccessKey, Host, BucketAccessType, SslOpts) ->
-    #config{
-     access_key_id=AccessKeyID,
-     secret_access_key=SecretAccessKey,
-     s3_url=Host,
-     bucket_access_type=BucketAccessType,
-     ssl_options=SslOpts}.
-
-
+% erlcloud has no new/5, and arguments differ.
+% for now, attempting conversion to new/4 (dropping SslOpts).
+% see: https://github.com/chef/chef-server/issues/2171
+-spec new(string() | binary(), string() | binary(), string(), bucket_access_type(), proplists:proplist()) -> aws_config().
+new(AccessKeyID, SecretAccessKey, Host, BucketAccessType, _SslOpts) ->
+    new(AccessKeyID, SecretAccessKey, Host, BucketAccessType).
 
 -define(XMLNS_S3, "http://s3.amazonaws.com/doc/2006-03-01/").
 
--spec copy_object(string(), string(), string(),
-                  string(), proplists:proplist()) -> proplists:proplist().
+-spec copy_object(string(), string(), string(), string(), proplists:proplist()) -> proplists:proplist().
 copy_object(DestBucketName, DestKeyName, SrcBucketName, SrcKeyName, Options) ->
-    copy_object(DestBucketName, DestKeyName, SrcBucketName,
-                SrcKeyName, Options, default_config()).
+    erlcloud_s3:copy_object(DestBucketName, DestKeyName, SrcBucketName, SrcKeyName, Options).
 
--spec copy_object(string(), string(), string(), string(),
-                  proplists:proplist(), config()) -> proplists:proplist().
+-spec copy_object(string(), string(), string(), string(), proplists:proplist(), aws_config()) -> proplists:proplist().
 copy_object(DestBucketName, DestKeyName, SrcBucketName, SrcKeyName, Options, Config) ->
-    SrcVersion = case proplists:get_value(version_id, Options) of
-                     undefined -> "";
-                     VersionID -> ["?versionId=", VersionID]
-                 end,
-    RequestHeaders =
-        [{"x-amz-copy-source", [SrcBucketName, $/, SrcKeyName, SrcVersion]},
-         {"x-amz-metadata-directive",
-          proplists:get_value(metadata_directive, Options)},
-         {"x-amz-copy-source-if-match", proplists:get_value(if_match, Options)},
-         {"x-amz-copy-source-if-none-match",
-          proplists:get_value(if_none_match, Options)},
-         {"x-amz-copy-source-if-unmodified-since",
-          proplists:get_value(if_unmodified_since, Options)},
-         {"x-amz-copy-source-if-modified-since",
-          proplists:get_value(if_modified_since, Options)},
-         {"x-amz-acl", encode_acl(proplists:get_value(acl, Options))}],
-    {Headers, _Body} = s3_request(Config, put, DestBucketName, [$/|DestKeyName],
-                                  "", [], <<>>, RequestHeaders),
-    [{copy_source_version_id,
-      proplists:get_value("x-amz-copy-source-version-id", Headers, "false")},
-     {version_id, proplists:get_value("x-amz-version-id", Headers, "null")}].
+    erlcloud_s3:copy_object(DestBucketName, DestKeyName, SrcBucketName, SrcKeyName, Options, Config).
 
--spec create_bucket(string(), bucket_acl(), location_constraint()) -> ok.
-
+-spec create_bucket(string(), s3_bucket_acl(), s3_location_constraint() | aws_config()) -> ok.
 create_bucket(BucketName, ACL, LocationConstraint) ->
-    create_bucket(BucketName, ACL, LocationConstraint, default_config()).
+    erlcloud_s3:create_bucket(BucketName, ACL, LocationConstraint).
 
--spec create_bucket(string(), bucket_acl(), location_constraint(), config()) -> ok.
+-spec create_bucket(string(), s3_bucket_acl(), s3_location_constraint(), aws_config()) -> ok.
+create_bucket(BucketName, ACL, LocationConstraint, Config) ->
+    erlcloud_s3:create_bucket(BucketName, ACL, LocationConstraint, Config).
 
-create_bucket(BucketName, ACL, LocationConstraint, Config)
-  when is_list(BucketName), is_atom(ACL), is_atom(LocationConstraint) ->
-    Headers = case ACL of
-                  private -> [];  %% private is the default
-                  _       -> [{"x-amz-acl", encode_acl(ACL)}]
-              end,
-    POSTData = case LocationConstraint of
-                   none -> <<>>;
-                   Location when Location =:= eu; Location =:= us_west_1 ->
-                       LocationName = case Location of
-                                          eu -> "EU";
-                                          us_west_1 -> "us-west-1"
-                                      end,
-                       XML = {'CreateBucketConfiguration', [{xmlns, ?XMLNS_S3}],
-                              [{'LocationConstraint', [LocationName]}]},
-                       list_to_binary(xmerl:export_simple([XML], xmerl_xml))
-               end,
-    s3_simple_request(Config, put, BucketName, "/", "", [], POSTData, Headers).
-
-encode_acl(undefined)                 -> undefined;
-encode_acl(private)                   -> "private";
-encode_acl(public_read)               -> "public-read";
-encode_acl(public_read_write)         -> "public-read-write";
-encode_acl(authenticated_read)        -> "authenticated-read";
-encode_acl(bucket_owner_read)         -> "bucket-owner-read";
-encode_acl(bucket_owner_full_control) -> "bucket-owner-full-control".
-
--spec delete_bucket(string()) -> ok.
-
-delete_bucket(BucketName) ->
-    delete_bucket(BucketName, default_config()).
-
--spec delete_bucket(string(), config()) -> ok.
-
-delete_bucket(BucketName, Config)
-  when is_list(BucketName) ->
-    s3_simple_request(Config, delete, BucketName, "/", "", [], <<>>, []).
+-spec delete_bucket(string(), aws_config()) -> ok.
+delete_bucket(BucketName, Config) ->
+    erlcloud_s3:delete_bucket(BucketName, Config).
 
 -spec delete_object(string(), string()) -> proplists:proplist().
-
 delete_object(BucketName, Key) ->
-    delete_object(BucketName, Key, default_config()).
+    erlcloud_s3:delete_object(BucketName, Key).
 
--spec delete_object(string(), string(), config()) -> proplists:proplist().
+-spec delete_object(string(), string(), aws_config()) -> proplists:proplist().
+delete_object(BucketName, Key, Config) ->
+    erlcloud_s3:delete_object(BucketName, Key, Config).
 
-delete_object(BucketName, Key, Config)
-  when is_list(BucketName), is_list(Key) ->
-    {Headers, _Body} = s3_request(Config, delete,
-                                  BucketName, [$/|Key], "", [], <<>>, []),
-    Marker = proplists:get_value("x-amz-delete-marker", Headers, "false"),
-    Id = proplists:get_value("x-amz-version-id", Headers, "null"),
-    [{delete_marker, list_to_existing_atom(Marker)},
-     {version_id, Id}].
-
--spec delete_object_version(string(), string(), string()) ->
-                                   proplists:proplist().
-
+-spec delete_object_version(string(), string(), string()) -> proplists:proplist().
 delete_object_version(BucketName, Key, Version) ->
-    delete_object_version(BucketName, Key, Version, default_config()).
+    erlcloud_s3:delete_object_version(BucketName, Key, Version).
 
--spec delete_object_version(string(), string(), string(), config()) ->
-                                   proplists:proplist().
+-spec delete_object_version(string(), string(), string(), aws_config()) -> proplists:proplist().
+delete_object_version(BucketName, Key, Version, Config) ->
+    erlcloud_s3:delete_object_version(BucketName, Key, Version, Config).
 
-delete_object_version(BucketName, Key, Version, Config)
-  when is_list(BucketName),
-       is_list(Key),
-       is_list(Version)->
-    {Headers, _Body} = s3_request(Config, delete, BucketName, [$/|Key],
-                                  "versionId=" ++ Version, [], <<>>, []),
-    Marker = proplists:get_value("x-amz-delete-marker", Headers, "false"),
-    Id = proplists:get_value("x-amz-version-id", Headers, "null"),
-    [{delete_marker, list_to_existing_atom(Marker)},
-     {version_id, Id}].
-
--spec list_buckets() -> proplists:proplist().
-
-list_buckets() ->
-    list_buckets(default_config()).
-
--spec list_buckets(config()) -> proplists:proplist().
-
+-spec list_buckets(aws_config()) -> proplists:proplist().
 list_buckets(Config) ->
-    Doc = s3_xml_request(Config, get, "", "/", "", [], <<>>, []),
-    Buckets = [extract_bucket(Node)
-               || Node <- xmerl_xpath:string("/*/Buckets/Bucket", Doc)],
-    [{buckets, Buckets}].
+    Result = erlcloud_s3:list_buckets(Config),
+    case proplists:lookup(buckets, Result) of none -> [{buckets, []}]; X -> [X] end.
 
 -spec list_objects(string(), proplists:proplist()) -> proplists:proplist().
-
 list_objects(BucketName, Options) ->
-    list_objects(BucketName, Options, default_config()).
+    erlcloud_s3:list_objects(BucketName, Options).
 
--spec list_objects(string(), proplists:proplist(), config()) ->
-                          proplists:proplist().
+-spec list_objects(string(), proplists:proplist(), aws_config()) -> proplists:proplist().
+list_objects(BucketName, Options, Config) ->
+    List = erlcloud_s3:list_objects(BucketName, Options, Config),
+    [{name, Name} | Rest] = List,
+    %[{name, http_uri:decode(Name)} | Rest].
+    [{name, decode(Name)} | Rest].
 
-list_objects(BucketName, Options, Config)
-  when is_list(BucketName),
-       is_list(Options) ->
-    Params = [{"delimiter", proplists:get_value(delimiter, Options)},
-              {"marker", proplists:get_value(marker, Options)},
-              {"max-keys", proplists:get_value(max_keys, Options)},
-              {"prefix", proplists:get_value(prefix, Options)}],
-    Doc = s3_xml_request(Config, get, BucketName, "/", "", Params, <<>>, []),
-    Attributes = [{name, "Name", text},
-                  {prefix, "Prefix", text},
-                  {marker, "Marker", text},
-                  {delimiter, "Delimiter", text},
-                  {max_keys, "MaxKeys", integer},
-                  {is_truncated, "IsTruncated", boolean},
-                  {contents, "Contents", fun extract_contents/1}],
-    ms3_xml:decode(Attributes, Doc).
-
-extract_contents(Nodes) ->
-    Attributes = [{key, "Key", text},
-                  {last_modified, "LastModified", time},
-                  {etag, "ETag", text},
-                  {size, "Size", integer},
-                  {storage_class, "StorageClass", text},
-                  {owner, "Owner", fun extract_user/1}],
-    [ms3_xml:decode(Attributes, Node) || Node <- Nodes].
-
-extract_user([Node]) ->
-    Attributes = [{id, "ID", text},
-                  {display_name, "DisplayName", optional_text}],
-    ms3_xml:decode(Attributes, Node).
-
--spec get_bucket_attribute(string(), bucket_attribute_name()) -> term().
-
+-spec get_bucket_attribute(string(), s3_bucket_attribute_name()) -> term().
 get_bucket_attribute(BucketName, AttributeName) ->
-    get_bucket_attribute(BucketName, AttributeName, default_config()).
+    erlcloud_s3:get_bucket_attribute(BucketName, AttributeName).
 
--spec get_bucket_attribute(string(), bucket_attribute_name(), config()) -> term().
+-spec get_bucket_attribute(string(), s3_bucket_attribute_name(), aws_config()) -> term().
+get_bucket_attribute(BucketName, AttributeName, Config) ->
+    erlcloud_s3:get_bucket_attribute(BucketName, AttributeName, Config).
 
-get_bucket_attribute(BucketName, AttributeName, Config)
-  when is_list(BucketName), is_atom(AttributeName) ->
-    Attr = case AttributeName of
-               acl             -> "acl";
-               location        -> "location";
-               logging         -> "logging";
-               request_payment -> "requestPayment";
-               versioning      -> "versioning"
-           end,
-    Doc = s3_xml_request(Config, get, BucketName, "/", Attr, [], <<>>, []),
-    case AttributeName of
-        acl ->
-            Attributes = [{owner, "Owner", fun extract_user/1},
-                          {access_control_list,
-                           "AccessControlList/Grant", fun extract_acl/1}],
-            ms3_xml:decode(Attributes, Doc);
-        location ->
-            ms3_xml:get_text("/LocationConstraint", Doc);
-        logging ->
-            case xmerl_xpath:string("/BucketLoggingStatus/LoggingEnabled", Doc) of
-                [] ->
-                    {enabled, false};
-                [LoggingEnabled] ->
-                    Attributes = [{target_bucket, "TargetBucket", text},
-                                  {target_prefix, "TargetPrefix", text},
-                                  {target_trants, "TargetGrants/Grant", fun extract_acl/1}],
-                    [{enabled, true}|ms3_xml:decode(Attributes, LoggingEnabled)]
-            end;
-        request_payment ->
-            case ms3_xml:get_text("/RequestPaymentConfiguration/Payer", Doc) of
-                "Requester" -> requester;
-                _           -> bucket_owner
-            end;
-        versioning ->
-            case ms3_xml:get_text("/VersioningConfiguration/Status", Doc) of
-                "Enabled"   -> enabled;
-                "Suspended" -> suspended;
-                _           -> disabled
-            end
-    end.
+%% Abstraction of universaltime, so it can be mocked via meck
+-spec universaltime() -> calendar:datetime().
+universaltime() ->
+    erlang:universaltime().
 
-extract_acl(ACL) ->
-    [extract_grant(Item) || Item <- ACL].
+-spec if_not_empty(string(), iolist()) -> iolist().
+if_not_empty("", _V) ->
+    "";
+if_not_empty(_, Value) ->
+    Value.
 
-extract_grant(Node) ->
-    [{grantee, extract_user(xmerl_xpath:string("Grantee", Node))},
-     {permission, decode_permission(ms3_xml:get_text("Permission", Node))}].
+-spec s3_url(atom(), string(), string(), non_neg_integer() | {non_neg_integer(), non_neg_integer()}, proplists:proplist(), aws_config()) -> binary().
+s3_url(Method, BucketName0, Key0, {TTL, ExpireWin}, RawHeaders, Config) ->
+    {Date, Lifetime} = make_expire_win(TTL, ExpireWin),
+    s3_url(Method, BucketName0, Key0, Lifetime, RawHeaders, Date, Config);
+s3_url(Method, BucketName0, Key0, Lifetime, RawHeaders, Config)
+  when is_list(BucketName0), is_list(Key0), is_tuple(Config) ->
+    [BucketName, Key] = [ms3_http:url_encode_loose(X) || X <- [BucketName0, Key0]],
+    RequestURI = erlcloud_s3:make_presigned_v4_url(Lifetime, BucketName, Method, Key, [], RawHeaders, Config),
+    iolist_to_binary(RequestURI).
 
-encode_permission(full_control) -> "FULL_CONTROL";
-encode_permission(write)        -> "WRITE";
-encode_permission(write_acp)    -> "WRITE_ACP";
-encode_permission(read)         -> "READ";
-encode_permission(read_acp) -> "READ_ACP".
+-spec s3_url(atom(), string(), string(), non_neg_integer(), proplists:proplist(), string(), aws_config()) -> binary().
+s3_url(Method, BucketName0, Key0, Lifetime, RawHeaders, Date, Config)
+  when is_list(BucketName0), is_list(Key0), is_tuple(Config) ->
+    [BucketName, Key] = [ms3_http:url_encode_loose(X) || X <- [BucketName0, Key0]],
+    RequestURI = erlcloud_s3:make_presigned_v4_url(Lifetime, BucketName, Method, Key, [], RawHeaders, Date, Config),
+    iolist_to_binary(RequestURI).
 
-decode_permission("FULL_CONTROL") -> full_control;
-decode_permission("WRITE")        -> write;
-decode_permission("WRITE_ACP")    -> write_acp;
-decode_permission("READ")         -> read;
-decode_permission("READ_ACP")     -> read_acp.
+%-----------------------------------------------------------------------------------
+% Implementation of expiration windows for sigv4, for making batches
+% of cacheable presigned URLs.
+%
+%          past       present      future
+%                        |
+% ------+------+------+--+---+------+------+------+------
+%       |      |      |  |   |      |      |      | time
+% ------+------+------+--+---+------+------+------+------
+%                     |    ^ |
+%      x-amz-date ----+    | +---- x-amz-expires
+%                        |-|
+%                        TTL
+%                     |------|
+%                     Lifetime
+%
+% Given a TTL, x-amz-expires should be set to be the closest expiry-window
+% boundary >= present+TTL, ie present+TTL selects the expiry-window. Squelch
+% any resulting Lifetime of greater than one week to one week.
+%
+% 1) Segment all of time into 'windows' of width expiry-window-size.
+% 2) Align x-amz-date to nearest expiry-window boundary less than present time.
+% 3) Align x-amz-expires to nearest expiry-window boundary greater than present time.
+% 4) The right edge of present+TTL is a 'selector' to determine which expiration
+%    window we are in, thus determining final value of x-amz-expires and Lifetime.
+% 5) While x-amz-expires - present < TTL, x-amz-expires += expiry-window-size.
+% 6) Lifetime = x-amz-expires - x-amz-date, or WEEKSEC, whichever is less.
+%-----------------------------------------------------------------------------------
+-define(WEEKSEC, 604800).
+-spec make_expire_win(non_neg_integer(), non_neg_integer()) -> {XAmzDate::string(), Lifetime::non_neg_integer()}.
+make_expire_win(TTL, ExpireWinSiz) when ExpireWinSiz > 0 ->
+    Present = calendar:datetime_to_gregorian_seconds(calendar:now_to_universal_time(os:timestamp())),
+    XAmzDateSec = Present div ExpireWinSiz * ExpireWinSiz,
+    ExpirWinMult = ((TTL div ExpireWinSiz) + (case TTL rem ExpireWinSiz > 0 of true -> 1; _ -> 0 end)),
+    XAmzExpires = case ExpirWinMult of 0 -> 1; _ -> ExpirWinMult end * ExpireWinSiz + XAmzDateSec,
+    Lifetime =
+        case (L = XAmzExpires - XAmzDateSec) > ?WEEKSEC of
+            true -> ?WEEKSEC;
+            _    -> L
+        end,
+    {erlcloud_aws:iso_8601_basic_time(calendar:gregorian_seconds_to_datetime(XAmzDateSec)), Lifetime}.
 
-
-%% @doc Canonicalizes a proplist of {"Header", "Value"} pairs by
-%% lower-casing all the Headers.
--spec canonicalize_headers([{string() | binary() | atom(), Value::string()}]) ->
-                                  [{LowerCaseHeader::string(), Value::string()}].
-canonicalize_headers(Headers) ->
-    [{string:to_lower(to_string(H)), V} || {H, V} <- Headers ].
-
--spec to_string(atom() | binary() | string()) -> string().
-to_string(A) when is_atom(A) ->
-    erlang:atom_to_list(A);
-to_string(B) when is_binary(B) ->
-    erlang:binary_to_list(B);
-to_string(S) when is_list(S) ->
-    S.
-
-%% @doc Retrieves a value from a set of canonicalized headers.  The
-%% given header should already be canonicalized (i.e., lower-cased).
-%% Returns the value or the empty string if no such value was found.
--spec retrieve_header_value(Header::string(),
-                            AllHeaders::[{Header::string(), Value::string()}]) ->
-                                   string().
-retrieve_header_value(Header, AllHeaders) ->
-    proplists:get_value(Header, AllHeaders, "").
-
+%-----------------------------------------------------------------------------------------
 %% calendar:datetime_to_gregorian_seconds({{1970, 1, 1}, {0, 0, 0}}).
 -define(EPOCH, 62167219200).
 -define(DAY, 86400).
@@ -437,483 +377,63 @@ expiration_time(TimeToLive) ->
     Now = calendar:datetime_to_gregorian_seconds(mini_s3:universaltime()),
     (Now - ?EPOCH) + TimeToLive.
 
-%% Abstraction of universaltime, so it can be mocked via meck
--spec universaltime() -> calendar:datetime().
-universaltime() ->
-    erlang:universaltime().
+%-----------------------------------------------------------------------------------------
 
--spec if_not_empty(string(), iolist()) -> iolist().
-if_not_empty("", _V) ->
-    "";
-if_not_empty(_, Value) ->
-    Value.
-
--spec format_s3_uri(config(), string()) -> string().
-format_s3_uri(#config{s3_url=S3Url, bucket_access_type=BAccessType}, Host) ->
-    {ok,{Protocol,UserInfo,Domain,Port,_Uri,_QueryString}} =
-        http_uri_:parse(S3Url, [{ipv6_host_with_brackets, true}]),
-    case BAccessType of
-        virtual_hosted ->
-            lists:flatten([erlang:atom_to_list(Protocol), "://",
-                           if_not_empty(Host, [Host, $.]),
-                           if_not_empty(UserInfo, [UserInfo, "@"]),
-                           Domain, ":", erlang:integer_to_list(Port)]);
-        path ->
-            lists:flatten([erlang:atom_to_list(Protocol), "://",
-                           if_not_empty(UserInfo, [UserInfo, "@"]),
-                           Domain, ":", erlang:integer_to_list(Port),
-                           if_not_empty(Host, [$/, Host])])
-    end.
-
-
-
-%% @doc Generate an S3 URL using Query String Request Authentication
-%% (see
-%% http://docs.amazonwebservices.com/AmazonS3/latest/dev/RESTAuthentication.html#RESTAuthenticationQueryStringAuth
-%% for details).
-%%
-%% Note that this is **NOT** a complete implementation of the S3 Query
-%% String Request Authentication signing protocol.  In particular, it
-%% does nothing with "x-amz-*" headers, nothing for virtual hosted
-%% buckets, and nothing for sub-resources.  It currently works for
-%% relatively simple use cases (e.g., providing URLs to which
-%% third-parties can upload specific files).
-%%
-%% Consult the official documentation (linked above) if you wish to
-%% augment this function's capabilities.
--spec s3_url(atom(), string(), string(), integer() | {integer(), integer()},
-             proplists:proplist(), config()) -> binary().
-s3_url(Method, BucketName, Key, Lifetime, RawHeaders,
-       Config = #config{access_key_id=AccessKey,
-                        secret_access_key=SecretKey})
-  when is_list(BucketName), is_list(Key) ->
-
-    Expires = erlang:integer_to_list(expiration_time(Lifetime)),
-
-    Path = lists:flatten([$/, BucketName, $/ , Key]),
-    CanonicalizedResource = ms3_http:url_encode_loose(Path),
-
-    {_StringToSign, Signature} = mini_s3:make_signed_url_authorization(SecretKey, Method,
-                                                               CanonicalizedResource,
-                                                               Expires, RawHeaders),
-
-    RequestURI = iolist_to_binary([
-                                   format_s3_uri(Config, ""), CanonicalizedResource,
-                                   $?, "AWSAccessKeyId=", AccessKey,
-                                   $&, "Expires=", Expires,
-                                   $&, "Signature=", ms3_http:url_encode_loose(Signature)
-                                  ]),
-    RequestURI.
-
-make_signed_url_authorization(SecretKey, Method, CanonicalizedResource,
-                              Expires, RawHeaders) ->
-    Headers = canonicalize_headers(RawHeaders),
-
-    HttpMethod = string:to_upper(atom_to_list(Method)),
-
-    ContentType = retrieve_header_value("content-type", Headers),
-    ContentMD5 = retrieve_header_value("content-md5", Headers),
-
-    %% We don't currently use this, but I'm adding a placeholder for future enhancements See
-    %% the URL in the docstring for details
-    CanonicalizedAMZHeaders = "",
-
-
-    StringToSign = lists:flatten([HttpMethod, $\n,
-                                  ContentMD5, $\n,
-                                  ContentType, $\n,
-                                  Expires, $\n,
-                                  CanonicalizedAMZHeaders, %% IMPORTANT: No newline here!!
-                                  CanonicalizedResource
-                                 ]),
-
-    Signature = base64:encode(crypto:mac(hmac, sha, SecretKey, StringToSign)),
-    {StringToSign, Signature}.
-
-
--spec get_object(string(), string(), proplists:proplist()) ->
-                        proplists:proplist().
-
-get_object(BucketName, Key, Options) ->
-    get_object(BucketName, Key, Options, default_config()).
-
--spec get_object(string(), string(), proplists:proplist(), config()) ->
-                        proplists:proplist().
-
+-spec get_object(string(), string(), proplists:proplist(), aws_config()) -> proplists:proplist().
 get_object(BucketName, Key, Options, Config) ->
-    RequestHeaders = [{"Range", proplists:get_value(range, Options)},
-                      {"If-Modified-Since", proplists:get_value(if_modified_since, Options)},
-                      {"If-Unmodified-Since", proplists:get_value(if_unmodified_since, Options)},
-                      {"If-Match", proplists:get_value(if_match, Options)},
-                      {"If-None-Match", proplists:get_value(if_none_match, Options)}],
-    Subresource = case proplists:get_value(version_id, Options) of
-                      undefined -> "";
-                      Version   -> ["versionId=", Version]
-                  end,
-    {Headers, Body} = s3_request(Config, get, BucketName, [$/|Key], Subresource, [], <<>>, RequestHeaders),
-    [{etag, proplists:get_value("etag", Headers)},
-     {content_length, proplists:get_value("content-length", Headers)},
-     {content_type, proplists:get_value("content-type", Headers)},
-     {delete_marker, list_to_existing_atom(proplists:get_value("x-amz-delete-marker", Headers, "false"))},
-     {version_id, proplists:get_value("x-amz-version-id", Headers, "null")},
-     {content, list_to_binary(Body)}|
-     extract_metadata(Headers)].
+    erlcloud_s3:get_object(BucketName, Key, Options, Config).
 
 -spec get_object_acl(string(), string()) -> proplists:proplist().
-
 get_object_acl(BucketName, Key) ->
-    get_object_acl(BucketName, Key, default_config()).
+    erlcloud_s3:get_object_acl(BucketName, Key).
 
--spec get_object_acl(string(), string(), proplists:proplist() | config()) -> proplists:proplist().
+-spec get_object_acl(string(), string(), proplists:proplist() | aws_config()) -> proplists:proplist().
+get_object_acl(BucketName, Key, Config) ->
+    erlcloud_s3:get_object_acl(BucketName, Key, Config).
 
-get_object_acl(BucketName, Key, Config)
-  when is_record(Config, config) ->
-    get_object_acl(BucketName, Key, [], Config);
+-spec get_object_acl(string(), string(), proplists:proplist(), aws_config()) -> proplists:proplist().
+get_object_acl(BucketName, Key, Options, Config) ->
+    erlcloud_s3:get_object_acl(BucketName, Key, Options, Config).
 
-get_object_acl(BucketName, Key, Options) ->
-    get_object_acl(BucketName, Key, Options, default_config()).
-
--spec get_object_acl(string(), string(), proplists:proplist(), config()) -> proplists:proplist().
-
-get_object_acl(BucketName, Key, Options, Config)
-  when is_list(BucketName), is_list(Key), is_list(Options) ->
-    Subresource = case proplists:get_value(version_id, Options) of
-                      undefined -> "";
-                      Version   -> ["&versionId=", Version]
-                  end,
-    Doc = s3_xml_request(Config, get, BucketName, [$/|Key], "acl" ++ Subresource, [], <<>>, []),
-    Attributes = [{owner, "Owner", fun extract_user/1},
-                  {access_control_list, "AccessControlList/Grant", fun extract_acl/1}],
-    ms3_xml:decode(Attributes, Doc).
-
--spec get_object_metadata(string(), string(), proplists:proplist()) -> proplists:proplist().
-
-get_object_metadata(BucketName, Key, Options) ->
-    get_object_metadata(BucketName, Key, Options, default_config()).
-
--spec get_object_metadata(string(), string(), proplists:proplist(), config()) -> proplists:proplist().
-
+-spec get_object_metadata(string(), string(), proplists:proplist(), aws_config()) -> proplists:proplist().
 get_object_metadata(BucketName, Key, Options, Config) ->
-    RequestHeaders = [{"If-Modified-Since", proplists:get_value(if_modified_since, Options)},
-                      {"If-Unmodified-Since", proplists:get_value(if_unmodified_since, Options)},
-                      {"If-Match", proplists:get_value(if_match, Options)},
-                      {"If-None-Match", proplists:get_value(if_none_match, Options)}],
-    Subresource = case proplists:get_value(version_id, Options) of
-                      undefined -> "";
-                      Version   -> ["versionId=", Version]
-                  end,
-    {Headers, _Body} = s3_request(Config, head, BucketName, [$/|Key], Subresource, [], <<>>, RequestHeaders),
-    [{last_modified, proplists:get_value("last-modified", Headers)},
-     {etag, proplists:get_value("etag", Headers)},
-     {content_length, proplists:get_value("content-length", Headers)},
-     {content_type, proplists:get_value("content-type", Headers)},
-     {delete_marker, list_to_existing_atom(proplists:get_value("x-amz-delete-marker", Headers, "false"))},
-     {version_id, proplists:get_value("x-amz-version-id", Headers, "false")}|extract_metadata(Headers)].
-
-extract_metadata(Headers) ->
-    [{Key, Value} || {["x-amz-meta-"|Key], Value} <- Headers].
+    erlcloud_s3:get_object_metadata(BucketName, Key, Options, Config).
 
 -spec get_object_torrent(string(), string()) -> proplists:proplist().
-
 get_object_torrent(BucketName, Key) ->
-    get_object_torrent(BucketName, Key, default_config()).
+    erlcloud_s3:get_object_torrent(BucketName, Key).
 
--spec get_object_torrent(string(), string(), config()) -> proplists:proplist().
-
+-spec get_object_torrent(string(), string(), aws_config()) -> proplists:proplist().
 get_object_torrent(BucketName, Key, Config) ->
-    {Headers, Body} = s3_request(Config, get, BucketName, [$/|Key], "torrent", [], <<>>, []),
-    [{delete_marker, list_to_existing_atom(proplists:get_value("x-amz-delete-marker", Headers, "false"))},
-     {version_id, proplists:get_value("x-amz-delete-marker", Headers, "false")},
-     {torrent, list_to_binary(Body)}].
+    erlcloud_s3:get_object_torrent(BucketName, Key, Config).
 
--spec list_object_versions(string(), proplists:proplist()) -> proplists:proplist().
-
+-spec list_object_versions(string(), proplists:proplist() | aws_config()) -> proplists:proplist().
 list_object_versions(BucketName, Options) ->
-    list_object_versions(BucketName, Options, default_config()).
+    erlcloud_s3:list_object_versions(BucketName, Options).
 
--spec list_object_versions(string(), proplists:proplist(), config()) -> proplists:proplist().
+-spec list_object_versions(string(), proplists:proplist(), aws_config()) -> proplists:proplist().
+list_object_versions(BucketName, Options, Config) ->
+    erlcloud_s3:list_object_versions(BucketName, Options, Config).
 
-list_object_versions(BucketName, Options, Config)
-  when is_list(BucketName), is_list(Options) ->
-    Params = [{"delimiter", proplists:get_value(delimiter, Options)},
-              {"key-marker", proplists:get_value(key_marker, Options)},
-              {"max-keys", proplists:get_value(max_keys, Options)},
-              {"prefix", proplists:get_value(prefix, Options)},
-              {"version-id-marker", proplists:get_value(version_id_marker, Options)}],
-    Doc = s3_xml_request(Config, get, BucketName, "/", "versions", Params, <<>>, []),
-    Attributes = [{name, "Name", text},
-                  {prefix, "Prefix", text},
-                  {key_marker, "KeyMarker", text},
-                  {next_key_marker, "NextKeyMarker", optional_text},
-                  {version_id_marker, "VersionIdMarker", text},
-                  {next_version_id_marker, "NextVersionIdMarker", optional_text},
-                  {max_keys, "MaxKeys", integer},
-                  {is_truncated, "Istruncated", boolean},
-                  {versions, "Version", fun extract_versions/1},
-                  {delete_markers, "DeleteMarker", fun extract_delete_markers/1}],
-    ms3_xml:decode(Attributes, Doc).
-
-extract_versions(Nodes) ->
-    [extract_version(Node) || Node <- Nodes].
-
-extract_version(Node) ->
-    Attributes = [{key, "Key", text},
-                  {version_id, "VersionId", text},
-                  {is_latest, "IsLatest", boolean},
-                  {etag, "ETag", text},
-                  {size, "Size", integer},
-                  {owner, "Owner", fun extract_user/1},
-                  {storage_class, "StorageClass", text}],
-    ms3_xml:decode(Attributes, Node).
-
-extract_delete_markers(Nodes) ->
-    [extract_delete_marker(Node) || Node <- Nodes].
-
-extract_delete_marker(Node) ->
-    Attributes = [{key, "Key", text},
-                  {version_id, "VersionId", text},
-                  {is_latest, "IsLatest", boolean},
-                  {owner, "Owner", fun extract_user/1}],
-    ms3_xml:decode(Attributes, Node).
-
-extract_bucket(Node) ->
-    ms3_xml:decode([{name, "Name", text},
-                    {creation_date, "CreationDate", time}],
-                   Node).
-
--spec put_object(string(),
-                 string(),
-                 iolist(),
-                 proplists:proplist(),
-                 [{string(), string()}]) -> [{'version_id', _}, ...].
-
-put_object(BucketName, Key, Value, Options, HTTPHeaders) ->
-    put_object(BucketName, Key, Value, Options, HTTPHeaders, default_config()).
-
--spec put_object(string(),
-                 string(),
-                 iolist(),
-                 proplists:proplist(),
-                 [{string(), string()}],
-                 config()) -> [{'version_id', _}, ...].
-
-put_object(BucketName, Key, Value, Options, HTTPHeaders, Config)
-  when is_list(BucketName), is_list(Key), is_list(Value) orelse is_binary(Value),
-       is_list(Options) ->
-    ContentType = proplists:get_value("content-type", HTTPHeaders, "application/octet_stream"),
-    FilteredHTTPHeaders = proplists:delete("content-type", HTTPHeaders),
-
-    RequestHeaders = [{"x-amz-acl", encode_acl(proplists:get_value(acl, Options))}|FilteredHTTPHeaders]
-        ++ [{["x-amz-meta-"|string:to_lower(MKey)], MValue} ||
-               {MKey, MValue} <- proplists:get_value(meta, Options, [])],
-    POSTData = {iolist_to_binary(Value), ContentType},
-    {Headers, _Body} = s3_request(Config, put, BucketName, [$/|Key], "", [],
-                                  POSTData, RequestHeaders),
-    [{version_id, proplists:get_value("x-amz-version-id", Headers, "null")}].
+-spec put_object(string(), string(), iodata(), proplists:proplist(), [{string(), string()}],  aws_config()) -> proplists:proplist().
+put_object(BucketName, Key, Value, Options, HTTPHeaders, Config) ->
+    erlcloud_s3:put_object(BucketName, Key, Value, Options, HTTPHeaders, Config).
 
 -spec set_object_acl(string(), string(), proplists:proplist()) -> ok.
-
 set_object_acl(BucketName, Key, ACL) ->
-    set_object_acl(BucketName, Key, ACL, default_config()).
+    erlcloud_s3:set_object_acl(BucketName, Key, ACL).
 
--spec set_object_acl(string(), string(), proplists:proplist(), config()) -> ok.
+-spec set_object_acl(string(), string(), proplists:proplist(), aws_config()) -> ok.
+set_object_acl(BucketName, Key, ACL, Config) ->
+    erlcloud_s3:set_object_acl(BucketName, Key, ACL, Config).
 
-set_object_acl(BucketName, Key, ACL, Config)
-  when is_list(BucketName), is_list(Key), is_list(ACL) ->
-    Id = proplists:get_value(id, proplists:get_value(owner, ACL)),
-    DisplayName = proplists:get_value(display_name, proplists:get_value(owner, ACL)),
-    ACL1 = proplists:get_value(access_control_list, ACL),
-    XML = {'AccessControlPolicy',
-           [{'Owner', [{'ID', [Id]}, {'DisplayName', [DisplayName]}]},
-            {'AccessControlList', encode_grants(ACL1)}]},
-    XMLText = list_to_binary(xmerl:export_simple([XML], xmerl_xml)),
-    s3_simple_request(Config, put, BucketName, [$/|Key], "acl", [], XMLText, []).
-
--spec set_bucket_attribute(string(),
-                           settable_bucket_attribute_name(),
-                           'bucket_owner' | 'requester' | [any()]) -> ok.
-
+-spec set_bucket_attribute(string(), atom(), term()) -> ok.
 set_bucket_attribute(BucketName, AttributeName, Value) ->
-    set_bucket_attribute(BucketName, AttributeName, Value, default_config()).
+    erlcloud_s3:set_bucket_attribute(BucketName, AttributeName, Value).
 
--spec set_bucket_attribute(string(), settable_bucket_attribute_name(),
-                           'bucket_owner' | 'requester' | [any()], config()) -> ok.
-
-set_bucket_attribute(BucketName, AttributeName, Value, Config)
-  when is_list(BucketName) ->
-    {Subresource, XML} =
-        case AttributeName of
-            acl ->
-                ACLXML = {'AccessControlPolicy',
-                          [{'Owner',
-                            [{'ID', [proplists:get_value(id, proplists:get_value(owner, Value))]},
-                             {'DisplayName', [proplists:get_value(display_name, proplists:get_value(owner, Value))]}]},
-                           {'AccessControlList', encode_grants(proplists:get_value(access_control_list, Value))}]},
-                {"acl", ACLXML};
-            logging ->
-                LoggingXML = {'BucketLoggingStatus',
-                              [{xmlns, ?XMLNS_S3}],
-                              case proplists:get_bool(enabled, Value) of
-                                  true ->
-                                      [{'LoggingEnabled',
-                                        [
-                                         {'TargetBucket', [proplists:get_value(target_bucket, Value)]},
-                                         {'TargetPrefix', [proplists:get_value(target_prefix, Value)]},
-                                         {'TargetGrants', encode_grants(proplists:get_value(target_grants, Value, []))}
-                                        ]
-                                       }];
-                                  false ->
-                                      []
-                              end},
-                {"logging", LoggingXML};
-            request_payment ->
-                PayerName = case Value of
-                                requester -> "Requester";
-                                bucket_owner -> "BucketOwner"
-                            end,
-                RPXML = {'RequestPaymentConfiguration', [{xmlns, ?XMLNS_S3}],
-                         [
-                          {'Payer', [PayerName]}
-                         ]
-                        },
-                {"requestPayment", RPXML};
-            versioning ->
-                Status = case proplists:get_value(status, Value) of
-                             suspended -> "Suspended";
-                             enabled -> "Enabled"
-                         end,
-                MFADelete = case proplists:get_value(mfa_delete, Value, disabled) of
-                                enabled -> "Enabled";
-                                disabled -> "Disabled"
-                            end,
-                VersioningXML = {'VersioningConfiguration', [{xmlns, ?XMLNS_S3}],
-                                 [{'Status', [Status]},
-                                  {'MfaDelete', [MFADelete]}]},
-                {"versioning", VersioningXML}
-        end,
-    POSTData = list_to_binary(xmerl:export_simple([XML], xmerl_xml)),
-    Headers = [{"content-type", "application/xml"}],
-    s3_simple_request(Config, put, BucketName, "/", Subresource, [], POSTData, Headers).
-
-encode_grants(Grants) ->
-    [encode_grant(Grant) || Grant <- Grants].
-
-encode_grant(Grant) ->
-    Grantee = proplists:get_value(grantee, Grant),
-    {'Grant',
-     [{'Grantee', [{xmlns, ?XMLNS_S3}],
-       [{'ID', [proplists:get_value(id, proplists:get_value(owner, Grantee))]},
-        {'DisplayName', [proplists:get_value(display_name, proplists:get_value(owner, Grantee))]}]},
-      {'Permission', [encode_permission(proplists:get_value(permission, Grant))]}]}.
-
-s3_simple_request(Config, Method, Host, Path, Subresource, Params, POSTData, Headers) ->
-    case s3_request(Config, Method, Host, Path,
-                    Subresource, Params, POSTData, Headers) of
-        {_Headers, ""} -> ok;
-        {_Headers, Body} ->
-            XML = element(1,xmerl_scan:string(Body)),
-            case XML of
-                #xmlElement{name='Error'} ->
-                    ErrCode = ms3_xml:get_text("/Error/Code", XML),
-                    ErrMsg = ms3_xml:get_text("/Error/Message", XML),
-                    erlang:error({s3_error, ErrCode, ErrMsg});
-                _ ->
-                    ok
-            end
-    end.
-
-s3_xml_request(Config, Method, Host, Path, Subresource, Params, POSTData, Headers) ->
-    {_Headers, Body} = s3_request(Config, Method, Host, Path,
-                                  Subresource, Params, POSTData, Headers),
-    XML = element(1,xmerl_scan:string(Body)),
-    case XML of
-        #xmlElement{name='Error'} ->
-            ErrCode = ms3_xml:get_text("/Error/Code", XML),
-            ErrMsg = ms3_xml:get_text("/Error/Message", XML),
-            erlang:error({s3_error, ErrCode, ErrMsg});
-        _ ->
-            XML
-    end.
-
-s3_request(Config = #config{access_key_id=AccessKey,
-                            secret_access_key=SecretKey,
-                            ssl_options=SslOpts},
-           Method, Host, Path, Subresource, Params, POSTData, Headers) ->
-    {ContentMD5, ContentType, Body} =
-        case POSTData of
-            {PD, CT} ->
-                {base64:encode(erlang:md5(PD)), CT, PD};
-            PD ->
-                %% On a put/post even with an empty body we need to
-                %% default to some content-type
-                case Method of
-                    _ when put == Method; post == Method ->
-                        {"", "text/xml", PD};
-                    _ ->
-                        {"", "", PD}
-                end
-        end,
-    AmzHeaders = lists:filter(fun ({"x-amz-" ++ _, V}) when
-                                        V =/= undefined -> true;
-                                  (_) -> false
-                              end, Headers),
-    Date = httpd_util:rfc1123_date(erlang:localtime()),
-    EscapedPath = ms3_http:url_encode_loose(Path),
-    {_StringToSign, Authorization} =
-        make_authorization(AccessKey, SecretKey, Method,
-                           ContentMD5, ContentType,
-                           Date, AmzHeaders, Host,
-                           EscapedPath, Subresource),
-    FHeaders = [Header || {_, Value} = Header <- Headers, Value =/= undefined],
-    RequestHeaders0 = [{"date", Date}, {"authorization", Authorization}|FHeaders] ++
-        case ContentMD5 of
-            "" -> [];
-            _ -> [{"content-md5", binary_to_list(ContentMD5)}]
-        end,
-    RequestHeaders1 = case proplists:is_defined("Content-Type", RequestHeaders0) of
-                          true ->
-                              RequestHeaders0;
-                          false ->
-                              [{"Content-Type", ContentType} | RequestHeaders0]
-                      end,
-    RequestURI = lists:flatten([format_s3_uri(Config, Host),
-                                EscapedPath,
-                                if_not_empty(Subresource, [$?, Subresource]),
-                                if
-                                    Params =:= [] -> "";
-                                    Subresource =:= "" -> [$?, ms3_http:make_query_string(Params)];
-                                    true -> [$&, ms3_http:make_query_string(Params)]
-                                end]),
-    IbrowseOpts = [ {ssl_options, SslOpts} ],
-    Response = case Method of
-                   get ->
-                       ibrowse:send_req(RequestURI, RequestHeaders1, Method, [], IbrowseOpts);
-                   delete ->
-                       ibrowse:send_req(RequestURI, RequestHeaders1, Method, [], IbrowseOpts);
-                   head ->
-                       %% ibrowse is unable to handle HEAD request responses that are sent
-                       %% with chunked transfer-encoding (why servers do this is not
-                       %% clear). While we await a fix in ibrowse, forcing the HEAD request
-                       %% to use HTTP 1.0 works around the problem.
-                       IbrowseOpts1 = [{http_vsn, {1, 0}} | IbrowseOpts],
-                       ibrowse:send_req(RequestURI, RequestHeaders1, Method, [],
-                                        IbrowseOpts1);
-                   _ ->
-                       ibrowse:send_req(RequestURI, RequestHeaders1, Method, Body, IbrowseOpts)
-               end,
-    case Response of
-        {ok, Status, ResponseHeaders0, ResponseBody} ->
-            ResponseHeaders = canonicalize_headers(ResponseHeaders0),
-            case erlang:list_to_integer(Status) of
-                OKStatus when OKStatus >= 200, OKStatus =< 299 ->
-                    {ResponseHeaders, ResponseBody};
-                BadStatus ->
-                    erlang:error({aws_error, {http_error, BadStatus,
-                                              {ResponseHeaders, ResponseBody}}})
-                end;
-        {error, Error} ->
-            erlang:error({aws_error, {socket_error, Error}})
-    end.
+-spec set_bucket_attribute(string(), atom(), term(), aws_config()) -> ok.
+set_bucket_attribute(BucketName, AttributeName, Value, Config) ->
+    erlcloud_s3:set_bucket_attribute(BucketName, AttributeName, Value, Config).
 
 make_authorization(AccessKeyId, SecretKey, Method, ContentMD5, ContentType, Date, AmzHeaders,
                    Host, Resource, Subresource) ->
@@ -930,15 +450,61 @@ make_authorization(AccessKeyId, SecretKey, Method, ContentMD5, ContentType, Date
     Signature = base64:encode(crypto:mac(hmac, sha, SecretKey, StringToSign)),
     {StringToSign, ["AWS ", AccessKeyId, $:, Signature]}.
 
-default_config() ->
-    Defaults =  envy:get(mini_s3, s3_defaults, list),
-    case proplists:is_defined(key_id, Defaults) andalso
-        proplists:is_defined(secret_access_key, Defaults) of
-        true ->
-            {key_id, Key} = proplists:lookup(key_id, Defaults),
-            {secret_access_key, AccessKey} =
-                proplists:lookup(secret_access_key, Defaults),
-            #config{access_key_id=Key, secret_access_key=AccessKey};
-        false ->
-            throw({error, missing_s3_defaults})
-    end.
+
+% ----------------------------------------------------
+% local functions
+% ----------------------------------------------------
+
+-spec decode(string() | binary()) -> string() | binary().
+decode(String) when is_list(String) ->
+    do_decode(String);
+decode(String) when is_binary(String) ->
+    do_decode_binary(String).
+
+do_decode([$%,Hex1,Hex2|Rest]) ->
+    [hex2dec(Hex1)*16+hex2dec(Hex2)|do_decode(Rest)];
+do_decode([First|Rest]) ->
+    [First|do_decode(Rest)];
+do_decode([]) ->
+    [].
+
+do_decode_binary(<<$%, Hex:2/binary, Rest/bits>>) ->
+    <<(binary_to_integer(Hex, 16)), (do_decode_binary(Rest))/binary>>;
+do_decode_binary(<<First:1/binary, Rest/bits>>) ->
+    <<First/binary, (do_decode_binary(Rest))/binary>>;
+do_decode_binary(<<>>) ->
+    <<>>.
+
+hex2dec(X) when (X>=$0) andalso (X=<$9) -> X-$0;
+hex2dec(X) when (X>=$A) andalso (X=<$F) -> X-$A+10;
+hex2dec(X) when (X>=$a) andalso (X=<$f) -> X-$a+10.
+
+% ----------------------------------------------------
+% currently unused
+% ----------------------------------------------------
+
+%-spec delete_bucket(string()) -> ok.
+%delete_bucket(BucketName) ->
+%    erlcloud_s3:delete_bucket(BucketName).
+
+%-spec get_object(string(), string(), proplists:proplist()) -> proplists:proplist().
+%get_object(BucketName, Key, Options) ->
+%    erlcloud_s3:get_object(BucketName, Key, Options).
+
+%-spec put_object(string(), string(), iodata(), proplists:proplist(), [{string(), string()}] | aws_config()) -> proplists:proplist().
+%put_object(BucketName, Key, Value, Options, HTTPHeaders) ->
+%    erlcloud_s3:put_object(BucketName, Key, Value, Options, HTTPHeaders).
+
+% for some functions which don't pass in Configs
+%default_config() ->
+%    Defaults =  envy:get(mini_s3, s3_defaults, list),
+%    case proplists:is_defined(key_id, Defaults) andalso
+%        proplists:is_defined(secret_access_key, Defaults) of
+%        true ->
+%            {key_id, Key} = proplists:lookup(key_id, Defaults),
+%            {secret_access_key, AccessKey} =
+%                proplists:lookup(secret_access_key, Defaults),
+%            #aws_config{access_key_id=Key, secret_access_key=AccessKey};
+%        false ->
+%            throw({error, missing_s3_defaults})
+%    end.

--- a/test/mini_s3_tests.erl
+++ b/test/mini_s3_tests.erl
@@ -19,112 +19,163 @@
 -module(mini_s3_tests).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("erlcloud/include/erlcloud_aws.hrl").
 -include("../src/internal.hrl").
+
+-spec format_s3_uri(aws_config(), string()) -> string().
+format_s3_uri(Config, Bucket) ->
+    erlcloud_s3:get_object_url(Bucket, "", Config).
 
 format_s3_uri_test_() ->
     Config = fun(Url, Type) ->
-                     #config{s3_url = Url, bucket_access_type = Type}
+                     mini_s3:new("", "", Url, Type)
              end,
     Tests = [
              %% hostname
-             {"https://my-aws.me.com", virtual_hosted, "https://bucket.my-aws.me.com:443"},
-             {"https://my-aws.me.com", path, "https://my-aws.me.com:443/bucket"},
+             {"https://my-aws.me.com", vhost, "https://bucket.my-aws.me.com:443/"},
+             {"https://my-aws.me.com", path,  "https://my-aws.me.com:443/bucket/"},
 
              %% ipv4
-             {"https://192.168.12.13", path, "https://192.168.12.13:443/bucket"},
+             {"https://192.168.12.13", path,  "https://192.168.12.13:443/bucket/"},
 
              %% ipv6
              {"https://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]", path,
-              "https://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:443/bucket"},
+              "https://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:443/bucket/"},
 
              %% These tests document current behavior. Using
-             %% virtual_hosted with an IP address does not make sense,
+             %% vhost with an IP address does not make sense,
              %% but leaving as-is for now to avoid adding the
              %% is_it_an_ip_or_a_name code.
-             {"https://192.168.12.13", virtual_hosted, "https://bucket.192.168.12.13:443"},
+             {"https://192.168.12.13", vhost, "https://bucket.192.168.12.13:443/"},
 
-             {"https://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]", virtual_hosted,
-              "https://bucket.[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:443"}
+             {"https://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]", vhost,
+              "https://bucket.[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:443/"}
             ],
-    [ ?_assertEqual(Expect, mini_s3:format_s3_uri(Config(Url, Type), "bucket"))
+    [ ?_assertEqual(Expect, format_s3_uri(Config(Url, Type), "bucket"))
       || {Url, Type, Expect} <- Tests ].
 
-%% 2015-01-27 00:00:00 = 1422316800 = ?MIDNIGHT
--define(MIDNIGHT, 1422316800).
--define(DAY, 86400).
--define(HOUR, 3600).
+% NOTE: this should be included in make_expire_win_test(), but timeout doesn't work unless the function is named main_test_().
+% note that this test is very sensitive to timing, and will fail if the timing is off.
+% for reference: -spec make_expire_win(TTL::non_neg_integer(), WinSize::non_neg_integer()) -> {XAmzDate::string(), Lifetime::non_neg_integer()}.
+main_test_() ->
+    {timeout, 60,
+        fun() ->
+                % 10 expiration windows of size 1sec created 1sec apart should be 10 unique windows (i.e. no duplicates)
+                Set1 = [{timer:sleep(1000), mini_s3:make_expire_win(0, 1)} || _ <- [1,2,3,4,5,6,7,8,9,0]],
+                10   = length(sets:to_list(sets:from_list(Set1))),
 
-expiration_time_test_() ->
-    Tests = [
-             %% {TTLSecs, IntervalSecs, MockedTimestamp, ExpectedExpiry}
-             {{3600, 900}, {{2015,1,27},{0,0,0}}  , (?MIDNIGHT + ?HOUR + 900)},
-             {{3600, 900}, {{2015,1,27},{0,0,10}} , (?MIDNIGHT + ?HOUR + 900)},
-             {{3600, 900}, {{2015,1,27},{0,1,0}}  , (?MIDNIGHT + ?HOUR + 900)},
-             {{3600, 900}, {{2015,1,27},{0,1,10}} , (?MIDNIGHT + ?HOUR + 900)},
-             {{3600, 900}, {{2015,1,27},{0,3,0}}  , (?MIDNIGHT + ?HOUR + 900)},
-             {{3600, 900}, {{2015,1,27},{0,3,30}} , (?MIDNIGHT + ?HOUR + 900)},
-             {{3600, 900}, {{2015,1,27},{0,5,0}}  , (?MIDNIGHT + ?HOUR + 900)},
-             {{3600, 900}, {{2015,1,27},{0,10,0}} , (?MIDNIGHT + ?HOUR + 900)},
-             {{3600, 900}, {{2015,1,27},{0,14,0}} , (?MIDNIGHT + ?HOUR + 900)},
-             {{3600, 900}, {{2015,1,27},{0,14,59}}, (?MIDNIGHT + ?HOUR + 900)},
-             {{3600, 900}, {{2015,1,27},{0,15,0}} , (?MIDNIGHT + ?HOUR + 1800)},
-             {{3600, 900}, {{2015,1,27},{0,15,1}} , (?MIDNIGHT + ?HOUR + 1800)},
-             {{3600, 900}, {{2015,1,27},{0,29,59}}, (?MIDNIGHT + ?HOUR + 1800)},
-             {{3600, 900}, {{2015,1,27},{0,30,0}} , (?MIDNIGHT + ?HOUR + 2700)},
-             {{3600, 900}, {{2015,1,27},{0,44,59}}, (?MIDNIGHT + ?HOUR + 2700)},
-             {{3600, 900}, {{2015,1,27},{0,45,0}} , (?MIDNIGHT + ?HOUR + 3600)},
-             {{3600, 900}, {{2015,1,27},{0,59,59}}, (?MIDNIGHT + ?HOUR + 3600)},
-             {{3600, 900}, {{2015,1,27},{1,0,0}}  , (?MIDNIGHT + ?HOUR + 4500)},
+                % 100 expiration windows of large size created quickly should be mostly duplicates
+                Set2 = [mini_s3:make_expire_win(0, 1000) || _ <- lists:duplicate(100, 0)],
+                true = 2 >= length(sets:to_list(sets:from_list(Set2)))
+        end
+    }.
+ 
+make_expire_win_test() ->
+    % test that this property holds:
+    %   lifetime >= ttl; lifetime >= expire_win_size
+    {_,    1} = mini_s3:make_expire_win(0,       1),
+    {_,    1} = mini_s3:make_expire_win(1,       1),
+    {_,    2} = mini_s3:make_expire_win(2,       1),
+    {_,  100} = mini_s3:make_expire_win(0,     100),
+    {_,  100} = mini_s3:make_expire_win(99,    100),
+    {_,  100} = mini_s3:make_expire_win(100,   100),
+    {_,   L0} = mini_s3:make_expire_win(101,   100),
+    true = L0 >= 101,
+    {_, 1000} = mini_s3:make_expire_win(0,    1000),
+    {_, 1000} = mini_s3:make_expire_win(999,  1000),
+    {_, 1000} = mini_s3:make_expire_win(1000, 1000),
+    {_,   L1} = mini_s3:make_expire_win(1001, 1000),
+    true = L1 >= 1001.
 
-             %% There are 86400 seconds in a day. What happens if the interval is not evenly
-             %% divisible in that time? Take 7m for example. 420 secs goes into a day 205.71
-             %% times which is a remainder of 300 seconds. We should make sure that we
-             %% restart the intervals at midnight, so we don't have day to day drift
+new_test() ->
+    % scheme://host:port
+    Config0    = mini_s3:new("key", "secret", "http://host:80"),
+    "http://"  = Config0#aws_config.s3_scheme,
+    "host"     = Config0#aws_config.s3_host,
+    80         = Config0#aws_config.s3_port,
 
-             {{3600, 420}, {{2015,1,27},{23,59,0}} , (?MIDNIGHT + ?DAY + ?HOUR)},
-             {{3600, 420}, {{2015,1,28},{0,0,0}}   , (?MIDNIGHT + ?DAY + ?HOUR + 420)},
+    Config1    = mini_s3:new("key", "secret", "https://host:80"),
+    "https://" = Config1#aws_config.s3_scheme,
+    "host"     = Config1#aws_config.s3_host,
+    80         = Config1#aws_config.s3_port,
 
-             %% Let's test the old functionality too
-             {3600, {{2015,1,27},{0,0,0}} , (?MIDNIGHT + ?HOUR)},
-             {3600, {{2015,1,27},{0,0,1}} , (?MIDNIGHT + ?HOUR + 1)},
-             {3600, {{2015,1,27},{0,1,1}} , (?MIDNIGHT + ?HOUR + 61)},
-             {3600, {{2015,1,28},{0,1,1}} , (?MIDNIGHT + ?DAY + ?HOUR + 61)}
-            ],
+    Config2    = mini_s3:new("key", "secret", "http://host:443"),
+    "http://"  = Config2#aws_config.s3_scheme,
+    "host"     = Config2#aws_config.s3_host,
+    443        = Config2#aws_config.s3_port,
 
-    TestFun = fun(Arg, MockedTime) ->
-                      meck:new(mini_s3, [unstick, passthrough]),
-                      meck:expect(mini_s3, universaltime, fun() -> MockedTime end),
-                      Expiry = mini_s3:expiration_time(Arg),
-                      meck:unload(mini_s3),
-                      Expiry
-              end,
-    [ ?_assertEqual(Expect, TestFun(Arg, MockedTimestamp))
-      || {Arg, MockedTimestamp, Expect} <- Tests].
+    Config3    = mini_s3:new("key", "secret", "https://host:443"),
+    "https://" = Config3#aws_config.s3_scheme,
+    "host"     = Config3#aws_config.s3_host,
+    443        = Config3#aws_config.s3_port, 
 
-s3_uri_test_() ->
-    Config = #config{
-               access_key_id = "access_key_id",
-               secret_access_key = "secret_access_key"
-               },
+    Config4    = mini_s3:new("key", "secret", "https://host:23"),
+    "https://" = Config4#aws_config.s3_scheme,
+    "host"     = Config4#aws_config.s3_host,
+    23         = Config4#aws_config.s3_port,
 
-    RawHeaders = [],
+    Config5    = mini_s3:new("key", "secret", "http://host:23"),
+    "http://"  = Config5#aws_config.s3_scheme,
+    "host"     = Config5#aws_config.s3_host,
+    23         = Config5#aws_config.s3_port,
 
-    TestFun = fun({Method, BucketName, Key, Lifetime, MockedTime}) ->
-                      meck:new(mini_s3, [no_link, passthrough]),
-                      meck:expect(mini_s3, universaltime, fun() -> MockedTime end),
-                      meck:expect(mini_s3, make_signed_url_authorization, fun(_,_,_,_,_) -> {"", <<"k6E/2haoGH5vGU9qDTBRs1qNGKA=">>} end),
+    Config00   = mini_s3:new("key", "secret", "http://[1234:1234:1234:1234:1234:1234:1234:1234]:80"),
+    "http://"  = Config00#aws_config.s3_scheme,
+    "[1234:1234:1234:1234:1234:1234:1234:1234]" = Config00#aws_config.s3_host,
+    80         = Config00#aws_config.s3_port,
 
-                      URL = binary_to_list(mini_s3:s3_url(Method, BucketName, Key, Lifetime, RawHeaders, Config)),
-                      io:format("URL: ~p~n", [URL]),
-                      io:format("History: ~p~n", [meck:history(mini_s3)]),
-                      meck:unload(mini_s3),
 
-                      URL
-              end,
+    % scheme://host
+    Config6    = mini_s3:new("key", "secret", "https://host"),
+    "https://" = Config6#aws_config.s3_scheme,
+    "host"     = Config6#aws_config.s3_host,
+    443        = Config6#aws_config.s3_port,
 
-    Tests = [
-             {{'GET', "BUCKET", "KEY", 3600, {{2015,1,27},{0,0,0}}}, "http://s3.amazonaws.com:80/BUCKET/KEY?AWSAccessKeyId=access_key_id&Expires=1422320400&Signature=k6E/2haoGH5vGU9qDTBRs1qNGKA%3D"},
-             {{'GET', "BUCKET2", "KEY2", {3600, 900}, {{2015,1,27},{0,0,0}}}, "http://s3.amazonaws.com:80/BUCKET2/KEY2?AWSAccessKeyId=access_key_id&Expires=1422321300&Signature=k6E/2haoGH5vGU9qDTBRs1qNGKA%3D"}
-            ],
+    Config7    = mini_s3:new("key", "secret", "http://host"),
+    "http://"  = Config7#aws_config.s3_scheme,
+    "host"     = Config7#aws_config.s3_host,
+    80         = Config7#aws_config.s3_port,
 
-    [ ?_assertEqual(Expect, TestFun(Args)) || {Args, Expect} <- Tests].
+    Config11   = mini_s3:new("key", "secret", "http://[1234:1234:1234:1234:1234:1234:1234:1234]"),
+    "http://"  = Config11#aws_config.s3_scheme,
+    "[1234:1234:1234:1234:1234:1234:1234:1234]" = Config11#aws_config.s3_host,
+    80         = Config11#aws_config.s3_port,
+
+
+    % host:port
+    Config99    = mini_s3:new("key", "secret", "127.0.0.1:4321"),
+    "https://"  = Config99#aws_config.s3_scheme,
+    "127.0.0.1" = Config99#aws_config.s3_host,
+    4321        = Config99#aws_config.s3_port,
+
+    Config8     = mini_s3:new("key", "secret", "host:80"),
+    "http://"   = Config8#aws_config.s3_scheme,
+    "host"      = Config8#aws_config.s3_host,
+    80          = Config8#aws_config.s3_port,
+
+    Config9     = mini_s3:new("key", "secret", "host:443"),
+    "https://"  = Config9#aws_config.s3_scheme,
+    "host"      = Config9#aws_config.s3_host,
+    443         = Config9#aws_config.s3_port,
+
+    ConfigA     = mini_s3:new("key", "secret", "host:23"),
+    "https://"  = ConfigA#aws_config.s3_scheme,
+    "host"      = ConfigA#aws_config.s3_host,
+    23          = ConfigA#aws_config.s3_port,
+
+    Config88    = mini_s3:new("key", "secret", "[1234:1234:1234:1234:1234:1234:1234:1234]:80"),
+    "http://"   = Config88#aws_config.s3_scheme,
+    "[1234:1234:1234:1234:1234:1234:1234:1234]" = Config88#aws_config.s3_host,
+    80          = Config88#aws_config.s3_port,
+
+
+    % host
+    ConfigB    = mini_s3:new("key", "secret", "host"),
+    "https://" = ConfigB#aws_config.s3_scheme,
+    "host"     = ConfigB#aws_config.s3_host,
+    443        = ConfigB#aws_config.s3_port,
+
+    ConfigBB   = mini_s3:new("key", "secret", "[1234:1234:1234:1234:1234:1234:1234:1234]"),
+    "https://" = ConfigBB#aws_config.s3_scheme,
+    "[1234:1234:1234:1234:1234:1234:1234:1234]" = ConfigBB#aws_config.s3_host,
+    443        = ConfigBB#aws_config.s3_port.


### PR DESCRIPTION
### Issues Resolved

https://github.com/chef/chef-server/issues/2088

### Related PRs

https://github.com/chef/chef-server/pull/2147

### Description

Configure mini_s3 for virtual host-style requests/URLs by default.  This is part of the effort to convert the chef-server system from path-style URLs to vhost-style URLs (see associated issue).

https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/1833#02060477-4ce7-4576-906b-a4f40d35f84e
https://buildkite.com/chef/chef-umbrella-master-chef-server/builds/92#6e485022-5f8c-48fe-a4cc-349fcdf8412f

Tested against S3:
```
Finished in 19 minutes 39 seconds (files took 3.27 seconds to load)
5195 examples, 0 failures, 128 pending
```

### Update

Amazon: "Update (September 23, 2020) – Over the last year, we’ve heard feedback from many customers who have asked us to extend the deprecation date. Based on this feedback we have decided to delay the deprecation of path-style URLs to ensure that customers have the time that they need to transition to virtual hosted-style URLs.

We have also heard feedback from customers that virtual hosted-style URLs should support buckets that have dots in their names for compatibility reasons, so we’re working on developing that support. Once we do, we will provide at least one full year prior to deprecating support for path-style URLs for new buckets."

### Instructions

Merge **AFTER** lbaker/presigned-headers has been merged.
UPDATE: Cherry-picked this commit onto lbaker/presigned-headers.  We will see what happens.